### PR TITLE
Make alias command more idiomatic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add alias commands: add, remove, show, [PR-6](https://github.com/reduct-storage/reduct-cli/pull/6)
 
+### Changed:
+
+- Make alias command more idiomatic, [PR-7](https://github.com/reduct-storage/reduct-cli/pull/7)
+
 ## [0.0.0] - 2022-10-17
 
 - Init release

--- a/docs/aliases.md
+++ b/docs/aliases.md
@@ -1,0 +1,19 @@
+# Aliases
+
+Reduct CLI client uses aliases to communicate with a storage engine, so that a user doesn't need to type its URL and
+credentials for every command.
+
+## Usage Example
+
+You can create an alias with the following comand:
+
+```shell
+reduct-cli alias add play
+```
+
+Now you can see it the new alias in list or check it URL:
+
+```shell
+reduct-cli alias ls
+reduct-cli alias show play # you can add -t flag to see token
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,9 @@
 site_name: CLI client for Reduct Storage
 docs_dir: .
 nav:
-  - Home: README.md
+  - Home:
+      - README.md
+      - docs/aliases.md
   - Reduct Storage: https://reduct-storage.dev
 
 repo_name: reduct-storage/reduct-cli

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,3 +62,7 @@ Blog = "https://dev.to/reduct-storage"
 
 [project.scripts]
 reduct-cli = "reduct_cli:main"
+
+
+[tool.pylint]
+good-names="ls,rm"

--- a/tests/alias_test.py
+++ b/tests/alias_test.py
@@ -1,5 +1,4 @@
 """Unit tests for alias command"""
-import json
 import time
 from functools import partial
 from pathlib import Path

--- a/tests/alias_test.py
+++ b/tests/alias_test.py
@@ -23,33 +23,32 @@ def _make_conf() -> Path:
     return Path(gettempdir()) / str(time.time_ns() % 1000000) / "config.toml"
 
 
+@pytest.fixture(name="url")
+def _make_url() -> str:
+    return "http://127.0.0.1:8383"
+
+
 def test__empty_list(runner, conf):
     """Should show empty aliases"""
-    result = runner(f"-c {conf} alias show")
+    result = runner(f"-c {conf} alias ls")
     assert result.exit_code == 0
-    assert result.output == "{}\n"
+    assert result.output == ""
 
 
-def test__add_alias_ok(runner, conf):
+def test__add_alias_ok(runner, conf, url):
     """Should add an alias"""
-    url = "http://127.0.0.1:8383"
     token = "token"
     result = runner(f"-c {conf} alias add storage", input=f"{url}\n{token}\n")
     assert result.exit_code == 0
 
-    result = runner(f"-c {conf} alias show")
+    result = runner(f"-c {conf} alias ls")
     assert result.exit_code == 0
-
-    json_output = json.loads(result.output)
-    json_output["storage"] = dict(url=url, token=token)
+    assert result.output == "storage\n"
 
 
-def test__add_alias_twice(runner, conf):
+def test__add_alias_twice(runner, conf, url):
     """Should not add an alias if the name alread exists"""
-
-    result = runner(
-        f"-c {conf} alias add storage", input="http://127.0.0.1:8383\ntoken\n"
-    )
+    result = runner(f"-c {conf} alias add storage", input=f"{url}\ntoken\n")
     assert result.exit_code == 0
 
     result = runner(f"-c {conf} alias add storage")
@@ -57,23 +56,48 @@ def test__add_alias_twice(runner, conf):
     assert result.output == "Alias 'storage' already exists\nAborted!\n"
 
 
-def test__rm_ok(runner, conf):
+def test__rm_ok(runner, conf, url):
     """Should remove alias"""
-    result = runner(
-        f"-c {conf} alias add storage", input="http://127.0.0.1:8383\ntoken\n"
-    )
+    result = runner(f"-c {conf} alias add storage", input=f"{url}\ntoken\n")
     assert result.exit_code == 0
 
-    result = runner(f"-c {conf} alias remove storage")
+    result = runner(f"-c {conf} alias rm storage")
     assert result.exit_code == 0
 
-    result = runner(f"-c {conf} alias show")
+    result = runner(f"-c {conf} alias ls")
     assert result.exit_code == 0
-    assert result.output == "{}\n"
+    assert result.output == ""
 
 
 def test__rm_not_exist(runner, conf):
     """Shouldn't remove alias if it doesn't exist"""
-    result = runner(f"-c {conf} alias remove storage")
+    result = runner(f"-c {conf} alias rm storage")
+    assert result.exit_code == 1
+    assert result.output == "Alias 'storage' doesn't exist\nAborted!\n"
+
+
+def test__show(runner, conf, url):
+    """Should show alias"""
+    result = runner(f"-c {conf} alias add storage", input=f"{url}\ntoken\n")
+    assert result.exit_code == 0
+
+    result = runner(f"-c {conf} alias show storage")
+    assert result.exit_code == 0
+    assert result.output.replace(" ", "") == f"URL:{url}\n"
+
+
+def test__show_with_token(runner, conf, url):
+    """Should show alias with token"""
+    result = runner(f"-c {conf} alias add storage", input=f"{url}\ntoken\n")
+    assert result.exit_code == 0
+
+    result = runner(f"-c {conf} alias show --token storage")
+    assert result.exit_code == 0
+    assert result.output.replace(" ", "") == f"URL:{url}\nToken:token\n"
+
+
+def test__show_not_exist(runner, conf):
+    """Should not show alias if alias doesn't exist"""
+    result = runner(f"-c {conf} alias show storage")
     assert result.exit_code == 1
     assert result.output == "Alias 'storage' doesn't exist\nAborted!\n"


### PR DESCRIPTION


### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Update

### What is the current behavior?

Name of command is not intuitive:

```
reduct-cli alias show   # print list
```

### What is the new behavior?


```
reduct-cli alias ls   # print list
reduct-cli alias show NAME   # print alias config
```

### Does this PR introduce a breaking change?

yes, but we haven't released yet

### Other information:
