### PR TITLE
Add `rcli` alias for `reduct-cli`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,11 @@ jobs:
       - name: Install package
         run: python3 -m pip install dist/*
 
-      - name: Check command
+      - name: Check `reduct-cli` command
         run: reduct-cli --help
 
+      - name: Check `rcli` command
+        run: rcli --help
   test:
     needs: build
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add `rcli` alias for `reduct-cli`, [PR-10](https://github.com/reduct-storage/reduct-cli/pull/10)
+
 ## [0.1.0] - 2022-10-24
 
 ### Added:

--- a/README.md
+++ b/README.md
@@ -17,6 +17,6 @@ pip install reduct-cli
 Check status of a demo server:
 
 ```shell
-reduct-cli alias add play # url: https://play.reduct-storage.dev, token: reduct
-reduct-cli server status play
+rcli alias add play # url: https://play.reduct-storage.dev, token: reduct
+rcli server status play
 ```

--- a/docs/aliases.md
+++ b/docs/aliases.md
@@ -8,12 +8,12 @@ credentials for every command.
 You can create an alias with the following command:
 
 ```shell
-reduct-cli alias add play
+rcli alias add play
 ```
 
 Now you can see it the new alias in list or check it URL:
 
 ```shell
-reduct-cli alias ls
-reduct-cli alias show play # you can add -t flag to see token
+rcli alias ls
+rcli alias show play # you can add -t flag to see token
 ```

--- a/docs/server.md
+++ b/docs/server.md
@@ -3,5 +3,5 @@
 If you set an [alias](./aliases.md) for your server, you can check its status:
 
 ```shell
-reduct-cli server status ALIAS
+rcli server status ALIAS
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ Blog = "https://dev.to/reduct-storage"
 
 [project.scripts]
 reduct-cli = "reduct_cli:main"
-
+rcli = "reduct_cli:main"
 
 [tool.pylint]
 good-names = "ls,rm"


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature

### What is the current behavior?

`reduct-cli` is too long. 

### What is the new behavior?

Pip installs `rcli` as a shortcut for `reduct-cli`

### Does this PR introduce a breaking change?

No

### Other information:
