### PR TITLE
Add options for  server URL and API token to `alias add` command 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Add `rcli` alias for `reduct-cli`, [PR-10](https://github.com/reduct-storage/reduct-cli/pull/10)
+### Added
 
+- `rcli` alias for `reduct-cli`, [PR-10](https://github.com/reduct-storage/reduct-cli/pull/10)
+- Options for server URL and API token to alias add command, [PR-11](https://github.com/reduct-storage/reduct-cli/pull/11)
+-
 ## [0.1.0] - 2022-10-24
 
 ### Added:

--- a/README.md
+++ b/README.md
@@ -20,3 +20,10 @@ Check status of a demo server:
 rcli alias add -L  https://play.reduct-storage.dev -t reduct play
 rcli server status play
 ```
+
+## Links
+
+* [Project Homepage](https://reduct-storage.dev)
+* [Documentation](https://reduct-cli.readthedocs.io/)
+* [Reduct Client SDK for Python](https://github.com/reduct-storage/reduct-py)
+* [Reduct Storage](https://github.com/reduct-storage/reduct-storage)

--- a/README.md
+++ b/README.md
@@ -17,6 +17,6 @@ pip install reduct-cli
 Check status of a demo server:
 
 ```shell
-rcli alias add play # url: https://play.reduct-storage.dev, token: reduct
+rcli alias add -L  https://play.reduct-storage.dev -t reduct play
 rcli server status play
 ```

--- a/docs/aliases.md
+++ b/docs/aliases.md
@@ -11,9 +11,21 @@ You can create an alias with the following command:
 rcli alias add play
 ```
 
+YOu can also provide a URL and API token as options:
+
+```shell
+rcli alias  add -L  https://play.reduct-storage.dev -t reduct play
+```
+
 Now you can see it the new alias in list or check it URL:
 
 ```shell
 rcli alias ls
 rcli alias show play # you can add -t flag to see token
+```
+
+To remove an alias, use command `rm`:
+
+```shell
+rcli alias rm play
 ```

--- a/reduct_cli/alias.py
+++ b/reduct_cli/alias.py
@@ -1,5 +1,6 @@
 """Alias commands"""
 from pathlib import Path
+from typing import Optional
 
 import click
 from click import Abort
@@ -48,18 +49,22 @@ def show(ctx, name: str, token: bool):
 
 @alias.command()
 @click.argument("name")
+@click.option("--url", "-L", help="Server URL")
+@click.option("--token", "-t", help="API token")
 @click.pass_context
-def add(ctx, name: str):
+def add(ctx, name: str, url: Optional[str], token: Optional[str]):
     """Add a new alias with NAME"""
     conf: Config = ctx.obj["conf"]
     if name in conf["aliases"]:
         error_console.print(f"Alias '{name}' already exists")
         raise Abort()
 
-    entry: Alias = dict(
-        url=click.prompt("URL", type=str),
-        token=click.prompt("API Token", type=str, default=""),
-    )
+    if url is None or len(url) == 0:
+        url = click.prompt("URL", type=str)
+    if token is None:
+        token = click.prompt("API Token", type=str, default="")
+
+    entry: Alias = dict(url=url, token=token)
 
     conf["aliases"][name] = entry
     write_config(ctx.obj["config_path"], conf)

--- a/tests/alias_test.py
+++ b/tests/alias_test.py
@@ -19,6 +19,17 @@ def test__add_alias_ok(runner, conf, url):
     assert result.output == "storage\n"
 
 
+def test__add_alias_with_options(runner, conf, url):
+    """Should add an alias"""
+    token = "token"
+    result = runner(f"-c {conf} alias add -L {url} -t {token} storage")
+    assert result.exit_code == 0
+
+    result = runner(f"-c {conf} alias ls")
+    assert result.exit_code == 0
+    assert result.output == "storage\n"
+
+
 def test__add_alias_twice(runner, conf, url):
     """Should not add an alias if the name alread exists"""
     result = runner(f"-c {conf} alias add storage", input=f"{url}\ntoken\n")


### PR DESCRIPTION
Closes #8 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature

### What is the current behavior?

A user should enter URL and token as promt

### What is the new behavior?

A user can pass the data as options:

```
rcli alias add -U https://play.reduct-storage.dev -t reduct play
```

### Does this PR introduce a breaking change?

No

### Other information:
