### PR TITLE
Improve output of `server status` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
+### Added:
 
 - `rcli` alias for `reduct-cli`, [PR-10](https://github.com/reduct-storage/reduct-cli/pull/10)
 - Options for server URL and API token to alias add command, [PR-11](https://github.com/reduct-storage/reduct-cli/pull/11)
--
+
+### Changed:
+
+- Improve output of server status command, [PR-12](https://github.com/reduct-storage/reduct-cli/pull/12)
 ## [0.1.0] - 2022-10-24
 
 ### Added:

--- a/reduct_cli/server.py
+++ b/reduct_cli/server.py
@@ -4,9 +4,9 @@ from asyncio import new_event_loop as loop
 import click
 from reduct import Client as ReductClient, ServerInfo
 
-from reduct_cli.humanize import time_interval, data_size
 from reduct_cli.alias import get_alias
 from reduct_cli.consoles import console, error_console
+from reduct_cli.humanize import time_interval
 
 run = loop().run_until_complete
 
@@ -28,11 +28,10 @@ def status(ctx, alias: str):
 
     try:
         info: ServerInfo = run(client.info())
-        console.print("Status: [green]Ok[/green]")
-        console.print(f"Version: {info.version}")
-        console.print(f"Uptime: {time_interval(info.uptime)}")
-        console.print(f"Usage: {data_size(info.usage)}")
-        console.print(f"Buckets: {info.bucket_count}")
+
+        console.print("Status:     [green]Ok[/green]")
+        console.print(f"Version:    {info.version}")
+        console.print(f"Uptime:     {time_interval(info.uptime)}")
 
     except Exception as err:  # pylint: disable=broad-except
         console.print("Status: [red]Error[/red]")

--- a/tests/server_test.py
+++ b/tests/server_test.py
@@ -31,8 +31,8 @@ def test__get_status(runner, conf, client):
     result = runner(f"-c {conf} server status test")
     assert result.exit_code == 0
     assert (
-        result.output
-        == "Status: Ok\nVersion: 1.0.0\nUptime: 15 minute(s)\nUsage: 1 MB\nBuckets: 5\n"
+        result.output.replace(" ", "")
+        == "Status:Ok\nVersion:1.0.0\nUptime:15minute(s)\n"
     )
 
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Update

### What is the current behavior?

The command prints too much information

### What is the new behavior?

It prints version and uptime


### Does this PR introduce a breaking change?

No

### Other information:
