### PR TITLE
Add `mirror` command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
         run: pylint ./reduct_cli/
 
       - name: Lint tests
-        run: pylint ./tests
+        run: PYTHONPATH=. pylint ./tests
 
 
   py-pip-upload:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added:
 
 - `rcli mirror` to copy data from a bucket to another
-  one, [PR-19](https://github.com/reduct-storage/reduct-cli/issues/19)
+  one, [PR-18](https://github.com/reduct-storage/reduct-cli/pull/18)
 
 ## [0.2.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-## [v0.2.0]
+
+### Added:
+
+- `rcli mirror` to copy data from a bucket to another
+  one, [PR-19](https://github.com/reduct-storage/reduct-cli/issues/19)
+
+## [0.2.0]
 
 ### Added:
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ CLI client for [Reduct Storage](https://reduct-storage.dev)
 * Bucket management
 * Server status
 * Aliases for servers' credentials
+* Mirroring data
 
 ## Requirements
 

--- a/docs/bucket.md
+++ b/docs/bucket.md
@@ -1,6 +1,6 @@
 # Bucket Commands
 
-If you set an [alias](./aliases.md) for your server, you can manage its buckets by using `bucket` subcommand:
+If you set an [alias](./aliases.md) for your server, you can manage its buckets by using the `bucket` subcommand:
 
 ```shell
 rcli bucket --help

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,9 @@
+# Command Line Interface
+
+::: mkdocs-click
+    :module: reduct_cli.cli
+    :command: cli
+    :prog_name: rcli
+    :style: table
+    :depth: 1
+    :list_subcommands: false

--- a/docs/mirror.md
+++ b/docs/mirror.md
@@ -1,0 +1,14 @@
+# Mirror data
+
+The CLI client provides the `mirror` command to copy data from a bucket to another one. The source and destination buckets
+could belong to one or two different storage engine.
+
+```shell
+rcli  mirror server-1/bucket server-2/bucket
+```
+
+A user can also specify a time interval for mirroring data with flags `--start` and `--stop`:
+
+```shell
+rcli  mirror --start 2022-11-06T20:10:30 --stop 2022-11-06T20:14:30  server-1/bucket server-2/bucket
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,9 +3,12 @@ docs_dir: .
 nav:
   - Home:
       - README.md
+  - Usage:
       - docs/aliases.md
       - docs/server.md
       - docs/bucket.md
+      - docs/mirror.md
+  - CLI Reference: docs/cli.md
   - Reduct Storage: https://reduct-storage.dev
 
 repo_name: reduct-storage/reduct-cli
@@ -61,6 +64,8 @@ markdown_extensions:
       check_paths: true
   - plantuml_markdown:
       format: svg
+  - mkdocs-click
+
 
 plugins:
   - same-dir

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ docs = [
     "mkdocs-material~=8.3",
     "plantuml-markdown~=3.5",
     "mkdocs-same-dir~=0.1",
+    "mkdocs-click~=0.8"
 ]
 
 [project.urls]

--- a/reduct_cli/alias.py
+++ b/reduct_cli/alias.py
@@ -9,17 +9,6 @@ from reduct_cli.config import Config, read_config, write_config, Alias
 from reduct_cli.consoles import console, error_console
 
 
-def get_alias(config_path: Path, name: str) -> Alias:
-    """Helper method to parse alias from config"""
-    conf = read_config(config_path)
-
-    if name not in conf["aliases"]:
-        error_console.print(f"Alias '{name}' doesn't exist")
-        raise Abort()
-    alias_: Alias = conf["aliases"][name]
-    return alias_
-
-
 @click.group()
 @click.pass_context
 def alias_cmd(ctx):

--- a/reduct_cli/alias.py
+++ b/reduct_cli/alias.py
@@ -1,5 +1,4 @@
 """Alias commands"""
-from pathlib import Path
 from typing import Optional
 
 import click
@@ -7,6 +6,7 @@ from click import Abort
 
 from reduct_cli.config import Config, read_config, write_config, Alias
 from reduct_cli.consoles import console, error_console
+from reduct_cli.helpers import get_alias
 
 
 @click.group()

--- a/reduct_cli/alias.py
+++ b/reduct_cli/alias.py
@@ -11,12 +11,12 @@ from reduct_cli.helpers import get_alias
 
 @click.group()
 @click.pass_context
-def alias_cmd(ctx):
+def alias(ctx):
     """Commands to manage aliases"""
     ctx.obj["conf"] = read_config(ctx.obj["config_path"])
 
 
-@alias_cmd.command()
+@alias.command()
 @click.pass_context
 def ls(ctx):
     """Print list of aliases"""
@@ -24,7 +24,7 @@ def ls(ctx):
         console.print(name)
 
 
-@alias_cmd.command()
+@alias.command()
 @click.argument("name")
 @click.option("--token/--no-token", "-t", help="Show token", default=False)
 @click.pass_context
@@ -36,7 +36,7 @@ def show(ctx, name: str, token: bool):
         console.print(f"[bold]Token[/bold]:\t\t{alias_['token']}")
 
 
-@alias_cmd.command()
+@alias.command()
 @click.argument("name")
 @click.option("--url", "-L", help="Server URL")
 @click.option("--token", "-t", help="API token")
@@ -59,7 +59,7 @@ def add(ctx, name: str, url: Optional[str], token: Optional[str]):
     write_config(ctx.obj["config_path"], conf)
 
 
-@alias_cmd.command()
+@alias.command()
 @click.argument("name")
 @click.pass_context
 def rm(ctx, name: str):

--- a/reduct_cli/bucket.py
+++ b/reduct_cli/bucket.py
@@ -3,7 +3,7 @@ from asyncio import new_event_loop as loop
 from typing import List, Optional
 
 import click
-from reduct import Client as ReductClient, BucketInfo, BucketSettings, QuotaType, Bucket
+from reduct import Client as ReductClient, BucketInfo, BucketSettings, QuotaType
 from rich.layout import Layout
 from rich.panel import Panel
 from rich.table import Table
@@ -23,8 +23,8 @@ async def _get_bucket_by_path(ctx, path):
     client = ReductClient(
         alias["url"], api_token=alias["token"], timeout=ctx.obj["timeout"]
     )
-    bucket: Bucket = await client.get_bucket(bucket_name)
-    return bucket
+
+    return await client.get_bucket(bucket_name)
 
 
 @click.group()

--- a/reduct_cli/bucket.py
+++ b/reduct_cli/bucket.py
@@ -28,11 +28,11 @@ async def _get_bucket_by_path(ctx, path):
 
 
 @click.group()
-def bucket_cmd():
+def bucket():
     """Commands to manage buckets"""
 
 
-@bucket_cmd.command()
+@bucket.command()
 @click.argument("alias")
 @click.option("--full/--no-full", help="Print full information", default=False)
 @click.pass_context
@@ -60,29 +60,29 @@ def ls(ctx, alias: str, full: bool):
             oldest_record = None
             latest_record = None
 
-            for bucket in buckets:
-                total_size += bucket.size
-                total_entry_count += bucket.entry_count
-                has_data = bucket.size > 0
+            for bucket_info in buckets:
+                total_size += bucket_info.size
+                total_entry_count += bucket_info.entry_count
+                has_data = bucket_info.size > 0
 
                 if has_data:
                     oldest_record = (
-                        min(oldest_record, bucket.oldest_record)
+                        min(oldest_record, bucket_info.oldest_record)
                         if oldest_record
-                        else bucket.oldest_record
+                        else bucket_info.oldest_record
                     )
                     latest_record = (
-                        max(latest_record, bucket.latest_record)
+                        max(latest_record, bucket_info.latest_record)
                         if latest_record
-                        else bucket.latest_record
+                        else bucket_info.latest_record
                     )
 
                 table.add_row(
-                    bucket.name,
-                    str(bucket.entry_count),
-                    pretty_size(bucket.size),
-                    print_datetime(bucket.oldest_record, has_data),
-                    print_datetime(bucket.latest_record, has_data),
+                    bucket_info.name,
+                    str(bucket_info.entry_count),
+                    pretty_size(bucket_info.size),
+                    print_datetime(bucket_info.oldest_record, has_data),
+                    print_datetime(bucket_info.latest_record, has_data),
                 )
 
             table.add_section()
@@ -96,11 +96,11 @@ def ls(ctx, alias: str, full: bool):
 
             console.print(table)
         else:
-            for bucket in buckets:
-                console.print(bucket.name)
+            for bucket_info in buckets:
+                console.print(bucket_info.name)
 
 
-@bucket_cmd.command()
+@bucket.command()
 @click.argument("path")
 @click.option("--full/--no-full", help="Print full information", default=False)
 @click.pass_context
@@ -112,9 +112,9 @@ def show(ctx, path: str, full: bool):
     """
 
     with error_handle():
-        bucket = run(_get_bucket_by_path(ctx, path))
+        bucket_ = run(_get_bucket_by_path(ctx, path))
 
-        info: BucketInfo = run(bucket.info())
+        info: BucketInfo = run(bucket_.info())
         history_interval = (info.latest_record - info.oldest_record) / 1000000
 
         info_txt = "\n".join(
@@ -132,7 +132,7 @@ def show(ctx, path: str, full: bool):
         else:
             # TODO: Fix when https://github.com/reduct-storage/reduct-py/issues/48 is done
 
-            settings: BucketSettings = run(bucket.get_settings())
+            settings: BucketSettings = run(bucket_.get_settings())
             settings_txt = "\n".join(
                 [
                     f"Quota Type:         {settings.quota_type.name}",
@@ -151,7 +151,7 @@ def show(ctx, path: str, full: bool):
             table.add_column("Latest Record (UTC)")
             table.add_column("History")
 
-            for entry in run(bucket.get_entry_list()):
+            for entry in run(bucket_.get_entry_list()):
                 table.add_row(
                     entry.name,
                     str(entry.record_count),
@@ -174,7 +174,7 @@ def show(ctx, path: str, full: bool):
             console.print(layout)
 
 
-@bucket_cmd.command()
+@bucket.command()
 @click.argument("path")
 @click.option("--quota-type", "-Q", help="Quota type. Must be NONE or FIFO")
 @click.option("--quota-size", "-s", help="Quota size in CI format e.g. 1Mb or 3TB")
@@ -210,7 +210,7 @@ def create(
         console.print(f"Bucket '{bucket_name}' created")
 
 
-@bucket_cmd.command()
+@bucket.command()
 @click.argument("path")
 @click.option("--quota-type", "-Q", help="Quota type. Must be NONE or FIFO")
 @click.option("--quota-size", "-s", help="Quota size in CI format e.g. 1Mb or 3TB")
@@ -230,7 +230,7 @@ def update(
     PATH should contain alias name and bucket name - ALIAS/BUCKET_NAME
     """
     with error_handle():
-        bucket = run(_get_bucket_by_path(ctx, path))
+        bucket_ = run(_get_bucket_by_path(ctx, path))
 
         settings = BucketSettings(
             quota_type=quota_type,
@@ -238,11 +238,11 @@ def update(
             max_block_size=parse_ci_size(block_size),
             max_block_records=block_records,
         )
-        run(bucket.set_settings(settings))
-        console.print(f"Bucket '{bucket.name}' was updated")
+        run(bucket_.set_settings(settings))
+        console.print(f"Bucket '{bucket_.name}' was updated")
 
 
-@bucket_cmd.command()
+@bucket.command()
 @click.argument("path")
 @click.pass_context
 def rm(ctx, path: str):
@@ -252,12 +252,12 @@ def rm(ctx, path: str):
     PATH should contain alias name and bucket name - ALIAS/BUCKET_NAME
     """
     with error_handle():
-        bucket = run(_get_bucket_by_path(ctx, path))
+        bucket_ = run(_get_bucket_by_path(ctx, path))
         console.print(
-            f"All data in bucket [b]'{bucket.name}'[/b] will be [b]REMOVED[/b]."
+            f"All data in bucket [b]'{bucket_.name}'[/b] will be [b]REMOVED[/b]."
         )
         if click.confirm("Do you want to continue?"):
-            run(bucket.remove())
-            console.print(f"Bucket '{bucket.name}' was removed")
+            run(bucket_.remove())
+            console.print(f"Bucket '{bucket_.name}' was removed")
         else:
             console.print("Canceled")

--- a/reduct_cli/cli.py
+++ b/reduct_cli/cli.py
@@ -9,6 +9,7 @@ from reduct_cli.config import write_config
 from reduct_cli.alias import alias_cmd
 from reduct_cli.bucket import bucket_cmd
 from reduct_cli.server import server_cmd
+from reduct_cli.mirror import mirror
 
 
 @click.group()
@@ -35,3 +36,4 @@ def cli(ctx, config: Optional[Path] = None):
 cli.add_command(alias_cmd, "alias")
 cli.add_command(bucket_cmd, "bucket")
 cli.add_command(server_cmd, "server")
+cli.add_command(mirror, "mirror")

--- a/reduct_cli/cli.py
+++ b/reduct_cli/cli.py
@@ -6,9 +6,9 @@ from typing import Optional
 import click
 
 from reduct_cli.config import write_config
-from reduct_cli.alias import alias_cmd
-from reduct_cli.bucket import bucket_cmd
-from reduct_cli.server import server_cmd
+from reduct_cli.alias import alias
+from reduct_cli.bucket import bucket
+from reduct_cli.server import server
 from reduct_cli.mirror import mirror
 
 
@@ -18,7 +18,7 @@ from reduct_cli.mirror import mirror
     "--config",
     "-c",
     type=Path,
-    help="Path to config file (${HOME}/.reduct-cli/config.toml)",
+    help="Path to config file. Default ${HOME}/.reduct-cli/config.toml",
 )
 @click.pass_context
 def cli(ctx, config: Optional[Path] = None):
@@ -33,7 +33,7 @@ def cli(ctx, config: Optional[Path] = None):
     ctx.obj["timeout"] = 3.0
 
 
-cli.add_command(alias_cmd, "alias")
-cli.add_command(bucket_cmd, "bucket")
-cli.add_command(server_cmd, "server")
+cli.add_command(alias, "alias")
+cli.add_command(bucket, "bucket")
+cli.add_command(server, "server")
 cli.add_command(mirror, "mirror")

--- a/reduct_cli/helpers.py
+++ b/reduct_cli/helpers.py
@@ -3,10 +3,9 @@ from pathlib import Path
 from typing import Tuple
 
 from click import Abort
-from reduct import Bucket, Client
 
-from reduct_cli.consoles import error_console
 from reduct_cli.config import read_config, Alias
+from reduct_cli.consoles import error_console
 
 
 def get_alias(config_path: Path, name: str) -> Alias:
@@ -21,17 +20,10 @@ def get_alias(config_path: Path, name: str) -> Alias:
 
 
 def parse_path(path) -> Tuple[str, str]:
+    """Parse path ALIAS/BUCKET"""
     args = path.split("/")
     if len(args) != 2:
         raise RuntimeError(
             f"Path {path} has wrong format. It must be 'ALIAS/BUCKET_NAME'"
         )
     return tuple(args)
-
-
-async def get_bucket_by_path(ctx, path):
-    alias_name, bucket_name = parse_path(path)
-    alias = get_alias(ctx.obj["config_path"], alias_name)
-    client = Client(alias["url"], api_token=alias["token"], timeout=ctx.obj["timeout"])
-    bucket: Bucket = await client.get_bucket(bucket_name)
-    return bucket

--- a/reduct_cli/helpers.py
+++ b/reduct_cli/helpers.py
@@ -1,0 +1,37 @@
+"""Helper functions"""
+from pathlib import Path
+from typing import Tuple
+
+from click import Abort
+from reduct import Bucket, Client
+
+from reduct_cli.consoles import error_console
+from reduct_cli.config import read_config, Alias
+
+
+def get_alias(config_path: Path, name: str) -> Alias:
+    """Helper method to parse alias from config"""
+    conf = read_config(config_path)
+
+    if name not in conf["aliases"]:
+        error_console.print(f"Alias '{name}' doesn't exist")
+        raise Abort()
+    alias_: Alias = conf["aliases"][name]
+    return alias_
+
+
+def parse_path(path) -> Tuple[str, str]:
+    args = path.split("/")
+    if len(args) != 2:
+        raise RuntimeError(
+            f"Path {path} has wrong format. It must be 'ALIAS/BUCKET_NAME'"
+        )
+    return tuple(args)
+
+
+async def get_bucket_by_path(ctx, path):
+    alias_name, bucket_name = parse_path(path)
+    alias = get_alias(ctx.obj["config_path"], alias_name)
+    client = Client(alias["url"], api_token=alias["token"], timeout=ctx.obj["timeout"])
+    bucket: Bucket = await client.get_bucket(bucket_name)
+    return bucket

--- a/reduct_cli/humanize.py
+++ b/reduct_cli/humanize.py
@@ -39,8 +39,9 @@ TB = GB * 1000
 
 
 def pretty_size(size: Union[int, float]) -> str:
-    size = int(size)
     """Return human-readable size"""
+
+    size = int(size)
     if size < 0:
         raise ValueError("Size must be positive")
 

--- a/reduct_cli/humanize.py
+++ b/reduct_cli/humanize.py
@@ -38,7 +38,8 @@ GB = MB * 1000
 TB = GB * 1000
 
 
-def pretty_size(size: int) -> str:
+def pretty_size(size: Union[int, float]) -> str:
+    size = int(size)
     """Return human-readable size"""
     if size < 0:
         raise ValueError("Size must be positive")

--- a/reduct_cli/mirror.py
+++ b/reduct_cli/mirror.py
@@ -1,0 +1,112 @@
+"""Mirror command"""
+import asyncio
+from datetime import datetime
+from typing import Optional
+
+import click
+from reduct import Client as ReductClient, ReductError, Bucket, EntryInfo
+from reduct_cli.error import error_handle
+from rich.progress import Progress
+
+from reduct_cli.helpers import parse_path, get_alias
+from reduct_cli.humanize import pretty_size
+
+
+async def _sync_entry(
+    entry: EntryInfo,
+    src_bucket: Bucket,
+    dest_bucket: Bucket,
+    start: Optional[int],
+    stop: Optional[int],
+    progress: Progress,
+):
+    progress_start = start if start else entry.oldest_record
+    progress_stop = stop if stop else entry.latest_record
+    last_time = progress_start
+    task = progress.add_task(
+        f"Entry '{entry.name}'", total=progress_stop - progress_start
+    )
+    mirrored_size = 0
+    async for record in src_bucket.query(entry.name, start=start, stop=stop):
+        try:
+            mirrored_size += record.size
+            await dest_bucket.write(
+                entry.name,
+                data=record.read(1024),
+                content_length=record.size,
+                timestamp=record.timestamp,
+            )
+        except ReductError as err:
+            if err.status_code != 409:
+                raise err
+
+        progress.update(
+            task,
+            description=f"Entry '{entry.name}' (copied {pretty_size(mirrored_size)})",
+            advance=record.timestamp - last_time,
+            refresh=True,
+        )
+        last_time = record.timestamp
+
+    progress.update(task, total=1, completed=True)
+
+
+async def _sync_bucket(
+    src_bucket_name: str,
+    dest_bucket_name: str,
+    src: ReductClient,
+    dest: ReductClient,
+    start: Optional[int],
+    stop: Optional[int],
+) -> None:
+    src_bucket: Bucket = await src.get_bucket(src_bucket_name)
+    dest_bucket: Bucket = await dest.create_bucket(
+        dest_bucket_name, settings=await src_bucket.get_settings(), exist_ok=True
+    )
+    with Progress() as progress:
+        tasks = [
+            _sync_entry(entry, src_bucket, dest_bucket, start, stop, progress)
+            for entry in await src_bucket.get_entry_list()
+        ]
+        await asyncio.gather(*tasks)
+
+
+@click.command()
+@click.argument("src")
+@click.argument("dest")
+@click.option(
+    "--start",
+    help="Mirror records with timestamps newer than this time point. Should be ISO date",
+)
+@click.option(
+    "--stop",
+    help="Mirror records  with timestamps older than this time point. Should be ISO date",
+)
+@click.pass_context
+def mirror(ctx, src: str, dest: str, start: Optional[str], stop: Optional[str]):
+    """Copy data from a service, bucket or entry to another one"""
+
+    with error_handle():
+        alias_name, src_bucket = parse_path(src)
+        alias = get_alias(ctx.obj["config_path"], alias_name)
+        src_instance = ReductClient(
+            alias["url"], api_token=alias["token"], timeout=ctx.obj["timeout"]
+        )
+
+        alias_name, dest_bucket = parse_path(dest)
+        alias = get_alias(ctx.obj["config_path"], alias_name)
+        dest_instance = ReductClient(
+            alias["url"], api_token=alias["token"], timeout=ctx.obj["timeout"]
+        )
+
+        if start:
+            start = int(datetime.fromisoformat(start).timestamp() * 1000_000)
+
+        if stop:
+            stop = int(datetime.fromisoformat(stop).timestamp() * 1000_000)
+
+        asyncio.new_event_loop().run_until_complete(
+            _sync_bucket(
+                src_bucket, dest_bucket, src_instance, dest_instance, start, stop
+            )
+        )

--- a/reduct_cli/mirror.py
+++ b/reduct_cli/mirror.py
@@ -4,10 +4,10 @@ from datetime import datetime
 from typing import Optional
 
 import click
-from reduct import Client as ReductClient, ReductError, Bucket, EntryInfo
-from reduct_cli.error import error_handle
 from rich.progress import Progress
+from reduct import Client as ReductClient, ReductError, Bucket, EntryInfo
 
+from reduct_cli.error import error_handle
 from reduct_cli.helpers import parse_path, get_alias
 from reduct_cli.humanize import pretty_size
 
@@ -16,18 +16,19 @@ async def _sync_entry(
     entry: EntryInfo,
     src_bucket: Bucket,
     dest_bucket: Bucket,
-    start: Optional[int],
-    stop: Optional[int],
     progress: Progress,
+    **kwargs,
 ):
-    progress_start = start if start else entry.oldest_record
-    progress_stop = stop if stop else entry.latest_record
+    progress_start = kwargs["start"] if kwargs["start"] else entry.oldest_record
+    progress_stop = kwargs["stop"] if kwargs["stop"] else entry.latest_record
     last_time = progress_start
     task = progress.add_task(
         f"Entry '{entry.name}'", total=progress_stop - progress_start
     )
     mirrored_size = 0
-    async for record in src_bucket.query(entry.name, start=start, stop=stop):
+    async for record in src_bucket.query(
+        entry.name, start=kwargs["start"], stop=kwargs["stop"]
+    ):
         try:
             mirrored_size += record.size
             await dest_bucket.write(
@@ -56,8 +57,7 @@ async def _sync_bucket(
     dest_bucket_name: str,
     src: ReductClient,
     dest: ReductClient,
-    start: Optional[int],
-    stop: Optional[int],
+    **kwargs,
 ) -> None:
     src_bucket: Bucket = await src.get_bucket(src_bucket_name)
     dest_bucket: Bucket = await dest.create_bucket(
@@ -65,7 +65,7 @@ async def _sync_bucket(
     )
     with Progress() as progress:
         tasks = [
-            _sync_entry(entry, src_bucket, dest_bucket, start, stop, progress)
+            _sync_entry(entry, src_bucket, dest_bucket, progress, **kwargs)
             for entry in await src_bucket.get_entry_list()
         ]
         await asyncio.gather(*tasks)
@@ -107,6 +107,11 @@ def mirror(ctx, src: str, dest: str, start: Optional[str], stop: Optional[str]):
 
         asyncio.new_event_loop().run_until_complete(
             _sync_bucket(
-                src_bucket, dest_bucket, src_instance, dest_instance, start, stop
+                src_bucket,
+                dest_bucket,
+                src_instance,
+                dest_instance,
+                start=start,
+                stop=stop,
             )
         )

--- a/reduct_cli/server.py
+++ b/reduct_cli/server.py
@@ -13,11 +13,11 @@ run = loop().run_until_complete
 
 
 @click.group()
-def server_cmd():
+def server():
     """Commands to manage server"""
 
 
-@server_cmd.command()
+@server.command()
 @click.argument("alias")
 @click.pass_context
 def status(ctx, alias: str):

--- a/reduct_cli/server.py
+++ b/reduct_cli/server.py
@@ -4,9 +4,9 @@ from asyncio import new_event_loop as loop
 import click
 from reduct import Client as ReductClient, ServerInfo
 
-from reduct_cli.alias import get_alias
 from reduct_cli.consoles import console
 from reduct_cli.error import error_handle
+from reduct_cli.helpers import get_alias
 from reduct_cli.humanize import pretty_time_interval
 
 run = loop().run_until_complete

--- a/tests/bucket_test.py
+++ b/tests/bucket_test.py
@@ -115,8 +115,8 @@ def test__get_error(runner, conf, client):
     """Should print error if something got wrong"""
     client.list.side_effect = RuntimeError("Oops")
     result = runner(f"-c {conf} bucket ls test")
-    assert result.exit_code == 1
     assert result.output == "[RuntimeError] Oops\nAborted!\n"
+    assert result.exit_code == 1
 
 
 @pytest.mark.usefixtures("set_alias", "client")
@@ -124,7 +124,6 @@ def test__show_bucket(runner, conf):
     """Should show bucket's info"""
 
     result = runner(f"-c {conf} bucket show test/bucket-1")
-    assert result.exit_code == 0
     assert result.output.split("\n") == [
         "Entry count:         1",
         "Size:                1 MB",
@@ -133,6 +132,7 @@ def test__show_bucket(runner, conf):
         "History Interval:    1 hour(s)",
         "",
     ]
+    assert result.exit_code == 0
 
 
 @pytest.mark.usefixtures("set_alias", "client")
@@ -140,7 +140,6 @@ def test__show_full_bucket(runner, conf):
     """Should show bucket's info"""
 
     result = runner(f"-c {conf} bucket show --full test/bucket-1")
-    assert result.exit_code == 0
     assert "Entry count:         1" in result.output
     assert "Oldest Record (UTC): 1970-01-01T00:16:40" in result.output
     assert "Latest Record (UTC): 1970-01-01T01:23:20" in result.output
@@ -152,6 +151,7 @@ def test__show_full_bucket(runner, conf):
     assert "Max. Block Records: 199" in result.output
 
     assert "entry-1" in result.output
+    assert result.exit_code == 0
 
 
 @pytest.mark.usefixtures("set_alias")
@@ -167,8 +167,8 @@ def test__show_error(runner, conf, client):
 def test__create_bucket_default(runner, conf, client):
     """Should create a bucket with default settings"""
     result = runner(f"-c {conf} bucket create test/bucket-1")
-    assert result.exit_code == 0
     assert result.output == "Bucket 'bucket-1' created\n"
+    assert result.exit_code == 0
 
     client.create_bucket.assert_called_with("bucket-1", BucketSettings())
 
@@ -180,8 +180,8 @@ def test__create_bucket_settings(runner, conf, client):
         f"-c {conf} bucket create "
         f"--quota-type FIFO --quota-size 100Gb --block-size 19Mb --block-records 100 test/bucket-1"
     )
-    assert result.exit_code == 0
     assert result.output == "Bucket 'bucket-1' created\n"
+    assert result.exit_code == 0
 
     client.create_bucket.assert_called_with(
         "bucket-1",
@@ -199,16 +199,16 @@ def test__create_error(runner, conf, client):
     """Should print error if something got wrong"""
     client.create_bucket.side_effect = RuntimeError("Oops")
     result = runner(f"-c {conf} bucket create test/bucket-1")
-    assert result.exit_code == 1
     assert result.output == "[RuntimeError] Oops\nAborted!\n"
+    assert result.exit_code == 1
 
 
 @pytest.mark.usefixtures("set_alias")
 def test__create_error_size(runner, conf, client):
     """Should print error if size is invalid"""
     result = runner(f"-c {conf} bucket create -s 100XX test/bucket-1")
-    assert result.exit_code == 1
     assert result.output == "[ValueError] Failed to parse 100XX\nAborted!\n"
+    assert result.exit_code == 1
 
     client.create_bucket.assert_not_called()
 
@@ -220,8 +220,8 @@ def test__create_update_settings(runner, conf, bucket):
         f"-c {conf} bucket update "
         f"--quota-type FIFO --quota-size 100Gb --block-size 19Mb --block-records 100 test/bucket-1"
     )
-    assert result.exit_code == 0
     assert result.output == "Bucket 'bucket-1' was updated\n"
+    assert result.exit_code == 0
 
     bucket.set_settings.assert_called_with(
         BucketSettings(
@@ -238,20 +238,20 @@ def test__update_error(runner, conf, bucket):
     """Should print error if something got wrong"""
     bucket.set_settings.side_effect = RuntimeError("Oops")
     result = runner(f"-c {conf} bucket update test/bucket-1")
-    assert result.exit_code == 1
     assert result.output == "[RuntimeError] Oops\nAborted!\n"
+    assert result.exit_code == 1
 
 
 @pytest.mark.usefixtures("set_alias", "client")
 def test__remove(runner, conf, bucket):
     """Should remove a bucket"""
     result = runner(f"-c {conf} bucket rm test/bucket-1", input="Y\n")
-    # assert result.exit_code == 0
     assert result.output == (
         "All data in bucket 'bucket-1' will be REMOVED.\n"
         "Do you want to continue? [y/N]: Y\n"
         "Bucket 'bucket-1' was removed\n"
     )
+    assert result.exit_code == 0
 
     bucket.remove.assert_called_once()
 
@@ -260,12 +260,12 @@ def test__remove(runner, conf, bucket):
 def test__remove_canceled(runner, conf, bucket):
     """Should cancel removing a bucket"""
     result = runner(f"-c {conf} bucket rm test/bucket-1", input="N\n")
-    # assert result.exit_code == 0
     assert result.output == (
         "All data in bucket 'bucket-1' will be REMOVED.\n"
         "Do you want to continue? [y/N]: N\n"
         "Canceled\n"
     )
+    assert result.exit_code == 0
 
     bucket.remove.assert_not_called()
 
@@ -275,10 +275,10 @@ def test__remove_error(runner, conf, bucket):
     """Should print error if something got wrong"""
     bucket.remove.side_effect = RuntimeError("Oops")
     result = runner(f"-c {conf} bucket rm test/bucket-1", input="Y\n")
-    assert result.exit_code == 1
     assert result.output == (
         "All data in bucket 'bucket-1' will be REMOVED.\n"
         "Do you want to continue? [y/N]: Y\n"
         "[RuntimeError] Oops\n"
         "Aborted!\n"
     )
+    assert result.exit_code == 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,12 +3,23 @@ import time
 from functools import partial
 from pathlib import Path
 from tempfile import gettempdir
-from typing import Callable
+from typing import Callable, Optional, List, Any
 
 import pytest
 from click.testing import CliRunner, Result
 
 from reduct_cli.cli import cli
+
+
+class AsyncIter:  # pylint: disable=too-few-public-methods
+    """Helper class for efficient mocking"""
+
+    def __init__(self, items: Optional[List[Any]] = None):
+        self.items = items if items else []
+
+    async def __aiter__(self):
+        for item in self.items:
+            yield item
 
 
 @pytest.fixture(name="runner")

--- a/tests/mirror_test.py
+++ b/tests/mirror_test.py
@@ -119,7 +119,8 @@ def test__mirror_ok(
 def test__mirror_ok_with_interval(runner, conf, src_bucket):
     """Should mirror a bucket to another one with time interval"""
     result = runner(
-        f"-c {conf} mirror --start 2022-01-02T00:00:01.100300+02:00 --stop 2022-02-01T00:00:00+02:00 "
+        f"-c {conf} mirror --start 2022-01-02T00:00:01.100300+02:00 "
+        f"--stop 2022-02-01T00:00:00+02:00 "
         f"test/src_bucket test/dest_bucket"
     )
     assert "Entry 'entry-1' (copied 6 B" in result.output

--- a/tests/mirror_test.py
+++ b/tests/mirror_test.py
@@ -119,14 +119,14 @@ def test__mirror_ok(
 def test__mirror_ok_with_interval(runner, conf, src_bucket):
     """Should mirror a bucket to another one with time interval"""
     result = runner(
-        f"-c {conf} mirror --start 2022-01-02T00:00:01.100300+02:00 --stop 2022-02-02+02:00 "
+        f"-c {conf} mirror --start 2022-01-02T00:00:01.100300+02:00 --stop 2022-02-01T00:00:00+02:00 "
         f"test/src_bucket test/dest_bucket"
     )
     assert "Entry 'entry-1' (copied 6 B" in result.output
     assert result.exit_code == 0
 
     src_bucket.query.assert_called_with(
-        "entry-1", start=1641074401100300, stop=1643763600000000
+        "entry-1", start=1641074401100300, stop=1643666400000000
     )
 
 

--- a/tests/mirror_test.py
+++ b/tests/mirror_test.py
@@ -1,0 +1,139 @@
+"""Unit tests for mirror command"""
+import asyncio
+from typing import List
+from unittest.mock import call, ANY
+
+import pytest
+from reduct import Client, Bucket, BucketSettings, EntryInfo
+from reduct.bucket import Record
+
+from tests.conftest import AsyncIter
+
+
+@pytest.fixture(name="src_settings")
+def _make_settings() -> BucketSettings:
+    return BucketSettings()
+
+
+@pytest.fixture(name="records")
+def _make_records() -> List[Record]:
+    def make_record(timestamp: int, data: bytes) -> Record:
+        async def read_all():
+            return data
+
+        async def read(_n: int):
+            yield data
+
+        return Record(
+            timestamp=timestamp, size=len(data), last=True, read_all=read_all, read=read
+        )
+
+    return [make_record(1000000000, b"Hey"), make_record(5000000000, b"Bye")]
+
+
+@pytest.fixture(name="src_bucket")
+def _make_src_bucket(mocker, src_settings, records) -> Bucket:
+    bucket = mocker.Mock(spec=Bucket)
+    bucket.name = "src_bucket"
+    bucket.get_settings.return_value = src_settings
+    bucket.get_entry_list.return_value = [
+        EntryInfo(
+            name="entry-1",
+            size=1050000,
+            block_count=1,
+            record_count=2,
+            oldest_record=1000000000,
+            latest_record=5000000000,
+        )
+    ]
+
+    bucket.query.return_value = AsyncIter(records)
+    return bucket
+
+
+@pytest.fixture(name="dest_bucket")
+def _make_dest_bucket(mocker) -> Bucket:
+    bucket = mocker.Mock(spec=Bucket)
+    bucket.name = "dest_bucket"
+
+    return bucket
+
+
+@pytest.fixture(name="client")
+def _make_client(mocker, src_bucket, dest_bucket) -> Client:
+    kls = mocker.patch("reduct_cli.mirror.ReductClient")
+    client = mocker.Mock(spec=Client)
+    client.get_bucket.return_value = src_bucket
+    client.create_bucket.return_value = dest_bucket
+
+    kls.return_value = client
+    return client
+
+
+def walk_async_iterator(iterator: AsyncIter):
+    """Walk through async iterator and return a list"""
+
+    async def walk():
+        return [data async for data in iterator]
+
+    return asyncio.new_event_loop().run_until_complete(walk())
+
+
+@pytest.mark.usefixtures("set_alias")
+def test__mirror_ok(
+    runner, conf, client, src_settings, src_bucket, dest_bucket, records
+):  # pylint: disable=too-many-arguments
+    """Should mirror a bucket to another one"""
+
+    result = runner(f"-c {conf} mirror test/src_bucket test/dest_bucket")
+    assert "Entry 'entry-1' (copied 6 B" in result.output
+    assert result.exit_code == 0
+
+    client.get_bucket.assert_called_with("src_bucket")
+    client.create_bucket.assert_called_with(
+        "dest_bucket", settings=src_settings, exist_ok=True
+    )
+
+    src_bucket.query.assert_called_with("entry-1", start=None, stop=None)
+    assert dest_bucket.write.await_args_list[0] == call(
+        "entry-1",
+        data=ANY,
+        content_length=records[0].size,
+        timestamp=records[0].timestamp,
+    )
+    assert walk_async_iterator(dest_bucket.write.await_args_list[0].kwargs["data"]) == [
+        b"Hey"
+    ]
+    assert dest_bucket.write.await_args_list[1] == call(
+        "entry-1",
+        data=ANY,
+        content_length=records[1].size,
+        timestamp=records[1].timestamp,
+    )
+    assert walk_async_iterator(dest_bucket.write.await_args_list[1].kwargs["data"]) == [
+        b"Bye"
+    ]
+
+
+@pytest.mark.usefixtures("set_alias", "client")
+def test__mirror_ok_with_interval(runner, conf, src_bucket):
+    """Should mirror a bucket to another one with time interval"""
+    result = runner(
+        f"-c {conf} mirror --start 2022-01-02T00:00:01.100300 --stop 2022-02-02 "
+        f"test/src_bucket test/dest_bucket"
+    )
+    assert "Entry 'entry-1' (copied 6 B" in result.output
+    assert result.exit_code == 0
+
+    src_bucket.query.assert_called_with(
+        "entry-1", start=1641078001100300, stop=1643756400000000
+    )
+
+
+@pytest.mark.usefixtures("set_alias")
+def test__get_error(runner, conf, client):
+    """Should print error if something got wrong"""
+    client.get_bucket.side_effect = RuntimeError("Oops")
+    result = runner(f"-c {conf} mirror test/src_bucket test/dest_bucket")
+    assert result.output == "[RuntimeError] Oops\nAborted!\n"
+    assert result.exit_code == 1

--- a/tests/mirror_test.py
+++ b/tests/mirror_test.py
@@ -119,14 +119,14 @@ def test__mirror_ok(
 def test__mirror_ok_with_interval(runner, conf, src_bucket):
     """Should mirror a bucket to another one with time interval"""
     result = runner(
-        f"-c {conf} mirror --start 2022-01-02T00:00:01.100300 --stop 2022-02-02 "
+        f"-c {conf} mirror --start 2022-01-02T00:00:01.100300+02:00 --stop 2022-02-02+02:00 "
         f"test/src_bucket test/dest_bucket"
     )
     assert "Entry 'entry-1' (copied 6 B" in result.output
     assert result.exit_code == 0
 
     src_bucket.query.assert_called_with(
-        "entry-1", start=1641078001100300, stop=1643756400000000
+        "entry-1", start=1641074401100300, stop=1643763600000000
     )
 
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature

### What is the current behavior?

There is no way to mirror data between buckets or instances of Reduct Storage.

### What is the new behavior?

```
rcli mirror ALIAS/SRC_BUCKET ALIAS/DEST_BUCKET
```

Copy data from `SRC_BUCKET` to `DEST_BUCKET`. If the destination bucket doesn't exist, it creates one with the settings of the source bucket. 

### Does this PR introduce a breaking change?

No

### Other information:
