### PR TITLE
Fix handling 409 HTTP error in `rcli mirror`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed:
+
+- 409 HTTP error in `rcli mirror`, [PR-27](https://github.com/reductstore/reduct-cli/pull/27)
+
 ## [0.4.0] - 2022-12-26
 
 ### Added:

--- a/reduct_cli/utils/helpers.py
+++ b/reduct_cli/utils/helpers.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Tuple
 
 from click import Abort
-from reduct import ReductError, EntryInfo, Bucket
+from reduct import EntryInfo, Bucket
 from rich.progress import Progress
 
 from reduct_cli.config import read_config, Alias

--- a/reduct_cli/utils/helpers.py
+++ b/reduct_cli/utils/helpers.py
@@ -63,13 +63,9 @@ async def read_records_with_progress(
     exported_size = 0
     start_op = time.time()
     async for record in bucket.query(entry.name, start=start, stop=stop):
-        try:
-            exported_size += record.size
-            yield record
+        exported_size += record.size
 
-        except ReductError as err:
-            if err.status_code != 409:
-                raise err
+        yield record
 
         progress.update(
             task,

--- a/tests/mirror_test.py
+++ b/tests/mirror_test.py
@@ -97,8 +97,8 @@ def test__get_error(runner, conf, client):
     assert result.exit_code == 1
 
 
-@pytest.mark.usefixtures("set_alias")
-def test__mirror_409(runner, conf, client, src_bucket, dest_bucket):
+@pytest.mark.usefixtures("set_alias", "client", "src_bucket")
+def test__mirror_409(runner, conf, dest_bucket):
     """Should skip record if it already exists in destination bucket"""
     dest_bucket.write.side_effect = ReductError(409, "Conflict")
     result = runner(f"-c {conf} mirror test/src_bucket test/dest_bucket")

--- a/tests/mirror_test.py
+++ b/tests/mirror_test.py
@@ -3,7 +3,7 @@ import asyncio
 from unittest.mock import call, ANY
 
 import pytest
-from reduct import Client, Bucket
+from reduct import Client, Bucket, ReductError
 
 from .conftest import AsyncIter
 
@@ -95,3 +95,12 @@ def test__get_error(runner, conf, client):
     result = runner(f"-c {conf} mirror test/src_bucket test/dest_bucket")
     assert result.output == "[RuntimeError] Oops\nAborted!\n"
     assert result.exit_code == 1
+
+
+@pytest.mark.usefixtures("set_alias")
+def test__mirror_409(runner, conf, client, src_bucket, dest_bucket):
+    """Should skip record if it already exists in destination bucket"""
+    dest_bucket.write.side_effect = ReductError(409, "Conflict")
+    result = runner(f"-c {conf} mirror test/src_bucket test/dest_bucket")
+    assert "Entry 'entry-1' (copied 6 B" in result.output
+    assert result.exit_code == 0


### PR DESCRIPTION
Closes #26 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

See #26 

### What is the new behavior?

I fixed the handling 409 HTTP error and it doesn't break the execution anymore.

### Does this PR introduce a breaking change?

No

### Other information:
