### PR TITLE
Add communication timeout as a global option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support `Z` designator for UTC timestamps in `rcli export` and `rcli mirror`
   commands, [PR-33](https://github.com/reductstore/reduct-cli/pull/33)
+- Communication timeout as a global option, [PR-34](https://github.com/reductstore/reduct-cli/pull/34)
 
 ### Fixed:
 

--- a/reduct_cli/cli.py
+++ b/reduct_cli/cli.py
@@ -22,8 +22,14 @@ from reduct_cli.export import export
     type=Path,
     help="Path to config file. Default ${HOME}/.reduct-cli/config.toml",
 )
+@click.option(
+    "--timeout",
+    "-t",
+    type=int,
+    help="Timeout for requests in seconds. Default 5",
+)
 @click.pass_context
-def cli(ctx, config: Optional[Path] = None):
+def cli(ctx, config: Optional[Path] = None, timeout: int = 5):
     """CLI admin tool for Reduct Storage"""
     if config is None:
         config = Path.home() / ".reduct-cli" / "config.toml"
@@ -32,7 +38,7 @@ def cli(ctx, config: Optional[Path] = None):
         write_config(config, {"aliases": {}})
 
     ctx.obj["config_path"] = config
-    ctx.obj["timeout"] = 3.0
+    ctx.obj["timeout"] = timeout
 
 
 cli.add_command(alias, "alias")


### PR DESCRIPTION
Closes #30

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature 

### What is the current behavior?

See #30

### What is the new behavior?

I added option `--timeout` or `-t` to pass the timeout in seconds

### Does this PR introduce a breaking change?

No

### Other information:
