### PR TITLE
Add  option `--parallel` to specify number of tasks for mirror and export commands

### DIFF
--- a/docs/export.md
+++ b/docs/export.md
@@ -39,6 +39,11 @@ Here is a list of the options that you can use with the `rcli export folder` com
   timestamps older than this time point will be included in the export. The time point should be in ISO format (e.g.,
   2022-01-01T00:00:00Z).
 
+You also can use the global `--parallel` option to specify the number of entries that you want to export in parallel:
+
+```
+rcli  --parallel 10  export folder myalias/mybucket ./exported-data
+```
 
 ### Examples
 

--- a/docs/mirror.md
+++ b/docs/mirror.md
@@ -39,6 +39,12 @@ Here is a list of the options that you can use with the rcli mirror command:
   timestamps
   older than this time point will be included in the copy. The time point should be in ISO format (e.g., 2022-01-01T00:00:00Z).
 
+You also can use the global `--parallel` option to specify the number of entries that you want to mirror in parallel:
+
+```
+rcli  --parallel 10  mirror myalias/mybucket myalias/newbucket
+```
+
 ## Examples
 
 Here are some examples of how you might use the `rcli mirror` command with the available options:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools>=40.8.0", "wheel"]
 [project]
 
 name = "reduct-cli"
-version = "0.4.0"
+version = "0.5.0"
 description = "CLI client for ReductStore"
 requires-python = ">=3.8"
 readme = "README.md"

--- a/reduct_cli/cli.py
+++ b/reduct_cli/cli.py
@@ -28,17 +28,35 @@ from reduct_cli.export import export
     type=int,
     help="Timeout for requests in seconds. Default 5",
 )
+@click.option(
+    "--parallel",
+    "-p",
+    type=int,
+    help="Number of parallel tasks to use, defaults to 10",
+)
 @click.pass_context
-def cli(ctx, config: Optional[Path] = None, timeout: int = 5):
+def cli(
+    ctx,
+    config: Optional[Path] = None,
+    timeout: Optional[int] = None,
+    parallel: Optional[int] = None,
+):
     """CLI admin tool for Reduct Storage"""
     if config is None:
         config = Path.home() / ".reduct-cli" / "config.toml"
+
+    if timeout is None:
+        timeout = 5
+
+    if parallel is None:
+        parallel = 10
 
     if not Path.exists(config):
         write_config(config, {"aliases": {}})
 
     ctx.obj["config_path"] = config
     ctx.obj["timeout"] = timeout
+    ctx.obj["parallel"] = parallel
 
 
 cli.add_command(alias, "alias")

--- a/reduct_cli/export.py
+++ b/reduct_cli/export.py
@@ -16,7 +16,7 @@ run = loop().run_until_complete
 
 @click.group()
 def export():
-    """Commands to export data from a bucket"""
+    """Export data from a bucket somewhere else"""
 
 
 async def _export_entry(

--- a/reduct_cli/export.py
+++ b/reduct_cli/export.py
@@ -20,12 +20,14 @@ def export():
 
 
 async def _export_entry(
-    path: Path, entry: EntryInfo, bucket: Bucket, progress: Progress, **kwargs
+    path: Path, entry: EntryInfo, bucket: Bucket, progress: Progress, sem, **kwargs
 ) -> None:
     entry_path = Path(path / entry.name)
     entry_path.mkdir(exist_ok=True)
 
-    async for record in read_records_with_progress(entry, bucket, progress, **kwargs):
+    async for record in read_records_with_progress(
+        entry, bucket, progress, sem, **kwargs
+    ):
         with open(entry_path / f"{record.timestamp}.bin", "wb") as file:
             async for chunk in record.read(1024):
                 file.write(chunk)
@@ -35,15 +37,17 @@ async def _export_bucket(
     client: ReductClient,
     dest: str,
     bucket_name: str,
+    parallel: int,
     **kwargs,
 ) -> None:
     bucket: Bucket = await client.get_bucket(bucket_name)
     folder_path = Path(dest) / bucket_name
-
     folder_path.mkdir(parents=True, exist_ok=True)
+    sem = asyncio.Semaphore(parallel)
+
     with Progress() as progress:
         tasks = [
-            _export_entry(folder_path, entry, bucket, progress, **kwargs)
+            _export_entry(folder_path, entry, bucket, progress, sem, **kwargs)
             for entry in await bucket.get_entry_list()
         ]
         await asyncio.gather(*tasks)
@@ -74,4 +78,13 @@ def folder(ctx, src: str, dest: str, start: Optional[str], stop: Optional[str]):
         client = ReductClient(
             alias["url"], api_token=alias["token"], timeout=ctx.obj["timeout"]
         )
-        run(_export_bucket(client, dest, bucket, start=start, stop=stop))
+        run(
+            _export_bucket(
+                client,
+                dest,
+                bucket,
+                parallel=ctx.obj["parallel"],
+                start=start,
+                stop=stop,
+            )
+        )


### PR DESCRIPTION
Closes #29

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature

### What is the current behavior?

See #29

### What is the new behavior?

I added a global option `--paralle`l to limit the number of entries for mirroring and exporting by using `asyncio.Semaphore`. 
No tests were added, because I didn't find a way to emulate it with mocks. 

### Does this PR introduce a breaking change?

No

### Other information:
