### PR TITLE
Add list of specific entries for export and mirror commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support `Z` designator for UTC timestamps in `rcli export` and `rcli mirror`
   commands, [PR-33](https://github.com/reductstore/reduct-cli/pull/33)
 - Communication timeout as a global option, [PR-34](https://github.com/reductstore/reduct-cli/pull/34)
+- `--entries` option to `rcli mirror` and `rcli export` commands, [PR-36](https://github.com/reductstore/reduct-cli/pull/36)
 
 ### Fixed:
 

--- a/docs/export.md
+++ b/docs/export.md
@@ -31,13 +31,16 @@ the exported-data folder on your desktop.
 
 Here is a list of the options that you can use with the `rcli export folder` command:
 
-* -`-start`: This option allows you to specify a starting time point for the data that you want to export. Data with
+* `--start`: This option allows you to specify a starting time point for the data that you want to export. Data with
   timestamps newer than this time point will be included in the export. The time point should be in ISO format (e.g.,
   2022-01-01T00:00:00Z).
 
-* -`-stop`: This option allows you to specify an ending time point for the data that you want to export. Data with
+* `--stop`: This option allows you to specify an ending time point for the data that you want to export. Data with
   timestamps older than this time point will be included in the export. The time point should be in ISO format (e.g.,
   2022-01-01T00:00:00Z).
+
+* `--entries`: With this option, you can specify the entries that you want to export. The entries should be specified
+  as a comma-separated list of entry names (e.g., `--entries=entry1,entry2`).
 
 You also can use the global `--parallel` option to specify the number of entries that you want to export in parallel:
 

--- a/docs/mirror.md
+++ b/docs/mirror.md
@@ -34,10 +34,12 @@ Here is a list of the options that you can use with the rcli mirror command:
 * `--start`: This option allows you to specify a starting time point for the data that you want to copy. Data with
   timestamps newer than this time point will be included in the copy. The time point should be in ISO format (e.g.,
   2022-01-01T00:00:00Z).
-
 * `--stop`: This option allows you to specify an ending time point for the data that you want to copy. Data with
-  timestamps
-  older than this time point will be included in the copy. The time point should be in ISO format (e.g., 2022-01-01T00:00:00Z).
+  timestamps older than this time point will be included in the copy. The time point should be in ISO format (e.g.,
+  2022-01-01T00:00:00Z).
+* `--entries`: With this option, you can specify the entries that you want to export. The entries should be
+  specified
+  as a comma-separated list of entry names (e.g., `--entries=entry1,entry2`).
 
 You also can use the global `--parallel` option to specify the number of entries that you want to mirror in parallel:
 
@@ -61,7 +63,8 @@ To copy all data from the `mybucket` bucket that was created before January 1, 2
 rcli mirror --stop 2022-01-01T00:00:00Z myalias/mybucket myalias/newbucket
 ```
 
-To copy all data from the `mybucket` bucket that was created between January 1, 2022 and January 31, 2022 to the `newbucket`
+To copy all data from the `mybucket` bucket that was created between January 1, 2022 and January 31, 2022 to
+the `newbucket`
 bucket:
 
 ```

--- a/reduct_cli/export.py
+++ b/reduct_cli/export.py
@@ -9,7 +9,12 @@ from reduct import Client as ReductClient, Bucket, EntryInfo
 from rich.progress import Progress
 
 from reduct_cli.utils.error import error_handle
-from reduct_cli.utils.helpers import parse_path, get_alias, read_records_with_progress
+from reduct_cli.utils.helpers import (
+    parse_path,
+    get_alias,
+    read_records_with_progress,
+    filter_entries,
+)
 
 run = loop().run_until_complete
 
@@ -48,7 +53,9 @@ async def _export_bucket(
     with Progress() as progress:
         tasks = [
             _export_entry(folder_path, entry, bucket, progress, sem, **kwargs)
-            for entry in await bucket.get_entry_list()
+            for entry in filter_entries(
+                await bucket.get_entry_list(), kwargs["entries"]
+            )
         ]
         await asyncio.gather(*tasks)
 
@@ -64,8 +71,15 @@ async def _export_bucket(
     "--stop",
     help="Mirror records  with timestamps older than this time point in ISO format",
 )
+@click.option(
+    "--entries",
+    help="Mirror only these entries, separated by comma",
+    default="",
+)
 @click.pass_context
-def folder(ctx, src: str, dest: str, start: Optional[str], stop: Optional[str]):
+def folder(
+    ctx, src: str, dest: str, start: Optional[str], stop: Optional[str], entries: str
+):
     """Export data from SRC bucket to DST folder
 
     SRC should be in the format of ALIAS/BUCKET_NAME
@@ -86,5 +100,6 @@ def folder(ctx, src: str, dest: str, start: Optional[str], stop: Optional[str]):
                 parallel=ctx.obj["parallel"],
                 start=start,
                 stop=stop,
+                entries=entries.split(","),
             )
         )

--- a/reduct_cli/export.py
+++ b/reduct_cli/export.py
@@ -79,7 +79,7 @@ async def _export_bucket(
 @click.pass_context
 def folder(
     ctx, src: str, dest: str, start: Optional[str], stop: Optional[str], entries: str
-):
+):  # pylint: disable=too-many-arguments
     """Export data from SRC bucket to DST folder
 
     SRC should be in the format of ALIAS/BUCKET_NAME

--- a/reduct_cli/mirror.py
+++ b/reduct_cli/mirror.py
@@ -82,7 +82,7 @@ async def _sync_bucket(
 @click.pass_context
 def mirror(
     ctx, src: str, dest: str, start: Optional[str], stop: Optional[str], entries: str
-):
+):  # pylint: disable=too-many-arguments
     """Copy data from SRC to DST bucket
 
     SRC and DST should be in the format of ALIAS/BUCKET_NAME

--- a/reduct_cli/utils/helpers.py
+++ b/reduct_cli/utils/helpers.py
@@ -83,7 +83,8 @@ async def read_records_with_progress(
 
             progress.update(
                 task,
-                description=f"Entry '{entry.name}' (copied {count} records ({pretty_size(exported_size)}), "
+                description=f"Entry '{entry.name}' "
+                f"(copied {count} records ({pretty_size(exported_size)}), "
                 f"speed {pretty_size(speed)}/s)",
                 advance=record.timestamp - last_time,
                 refresh=True,

--- a/reduct_cli/utils/helpers.py
+++ b/reduct_cli/utils/helpers.py
@@ -3,7 +3,7 @@ import time
 from asyncio import Semaphore
 from datetime import datetime
 from pathlib import Path
-from typing import Tuple
+from typing import Tuple, List
 
 from click import Abort
 from reduct import EntryInfo, Bucket
@@ -67,19 +67,45 @@ async def read_records_with_progress(
     task = progress.add_task(f"Entry '{entry.name}' waiting", total=stop - start)
     async with sem:
         exported_size = 0
-        start_op = time.time()
+        count = 0
+        stats = []
+        speed = 0
         async for record in bucket.query(entry.name, start=start, stop=stop):
             exported_size += record.size
+            stats.append((record.size, time.time()))
+            if len(stats) > 10:
+                stats.pop(0)
+
+            if len(stats) > 1:
+                speed = sum(s[0] for s in stats) / (stats[-1][1] - stats[0][1])
 
             yield record
 
             progress.update(
                 task,
-                description=f"Entry '{entry.name}' (copied {pretty_size(exported_size)}, "
-                f"speed {pretty_size(exported_size / (time.time() - start_op))}/s)",
+                description=f"Entry '{entry.name}' (copied {count} records ({pretty_size(exported_size)}), "
+                f"speed {pretty_size(speed)}/s)",
                 advance=record.timestamp - last_time,
                 refresh=True,
             )
             last_time = record.timestamp
+            count += 1
 
         progress.update(task, total=1, completed=True)
+
+
+def filter_entries(entries: List[EntryInfo], names: List[str]) -> List[EntryInfo]:
+    """Filter entries by names"""
+    if not names or len(names) == 0:
+        return entries
+
+    if len(names) == 1 and names[0] == "":
+        return entries
+
+    def _filter(entry):
+        for name in names:
+            if name == entry.name:
+                return True
+        return False
+
+    return list(filter(_filter, entries))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,7 +78,15 @@ def _make_src_bucket(mocker, src_settings, records) -> Bucket:
             record_count=2,
             oldest_record=1000000000,
             latest_record=5000000000,
-        )
+        ),
+        EntryInfo(
+            name="entry-2",
+            size=1050000,
+            block_count=1,
+            record_count=2,
+            oldest_record=1000000000,
+            latest_record=5000000000,
+        ),
     ]
 
     bucket.query.return_value = AsyncIter(records)

--- a/tests/export_test.py
+++ b/tests/export_test.py
@@ -43,7 +43,7 @@ def test__export_to_folder_ok_with_interval(runner, conf, src_bucket, records):
 
 
 @pytest.mark.usefixtures("set_alias", "client")
-def test__export_to_folder_ok_without_interval(runner, conf, src_bucket, records):
+def test__export_to_folder_ok_without_interval(runner, conf, src_bucket):
     """Should export a bucket to a fodder one without time interval"""
     path = Path(gettempdir()) / "reduct-test"
     result = runner(f"-c {conf} export folder test/src_bucket {path}")

--- a/tests/export_test.py
+++ b/tests/export_test.py
@@ -25,7 +25,7 @@ def test__export_to_folder_ok_with_interval(runner, conf, src_bucket, records):
         f"--stop 2022-02-01T00:00:00+02:00 "
         f"test/src_bucket {path}"
     )
-    assert "Entry 'entry-1' (copied 6 B" in result.output
+    assert "Entry 'entry-1' (copied 1 records (6 B)" in result.output
     assert result.exit_code == 0
 
     src_bucket.query.assert_called_with(
@@ -45,7 +45,7 @@ def test__export_to_folder_ok_without_interval(runner, conf, src_bucket, records
     """Should export a bucket to a fodder one without time interval"""
     path = Path(gettempdir()) / "reduct-test"
     result = runner(f"-c {conf} export folder test/src_bucket {path}")
-    assert "Entry 'entry-1' (copied 6 B" in result.output
+    assert "Entry 'entry-1' (copied 1 records (6 B)" in result.output
     assert result.exit_code == 0
 
     src_bucket.query.assert_called_with("entry-1", start=1000000000, stop=5000000000)

--- a/tests/mirror_test.py
+++ b/tests/mirror_test.py
@@ -43,7 +43,7 @@ def test__mirror_ok(
     """Should mirror a bucket to another one"""
 
     result = runner(f"-c {conf} mirror test/src_bucket test/dest_bucket")
-    assert "Entry 'entry-1' (copied 6 B" in result.output
+    assert "Entry 'entry-1' (copied 1 records (6 B)" in result.output
     assert result.exit_code == 0
 
     client.get_bucket.assert_called_with("src_bucket")
@@ -80,7 +80,7 @@ def test__mirror_ok_with_interval(runner, conf, src_bucket):
         f"--stop 2022-02-01T00:00:00+02:00 "
         f"test/src_bucket test/dest_bucket"
     )
-    assert "Entry 'entry-1' (copied 6 B" in result.output
+    assert "Entry 'entry-1' (copied 1 records (6 B)" in result.output
     assert result.exit_code == 0
 
     src_bucket.query.assert_called_with(
@@ -102,7 +102,6 @@ def test__mirror_409(runner, conf, dest_bucket):
     """Should skip record if it already exists in destination bucket"""
     dest_bucket.write.side_effect = ReductError(409, "Conflict")
     result = runner(f"-c {conf} mirror test/src_bucket test/dest_bucket")
-    assert "Entry 'entry-1' (copied 6 B" in result.output
     assert result.exit_code == 0
 
 


### PR DESCRIPTION
Closes #32

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature 

### What is the current behavior?

See #32 

### What is the new behavior?

I added the `--entries` option which has a comma-separated list of entries to `rcli export` and `rcli mirror` commands.

### Does this PR introduce a breaking change?

No

### Other information:
