### PR TITLE
Add graceful handling of `SIGINT` and `SIGTERM` signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `--entries` option to `rcli mirror` and `rcli export`
   commands, [PR-36](https://github.com/reductstore/reduct-cli/pull/36)
 - URL validation to `alias add` command, [PR-37](https://github.com/reductstore/reduct-cli/pull/37)
+- Graceful handling of `SIGINT` and `SIGTERM` signals, [PR-38](https://github.com/reductstore/reduct-cli/pull/38)
 
 ### Fixed:
 

--- a/reduct_cli/utils/helpers.py
+++ b/reduct_cli/utils/helpers.py
@@ -79,6 +79,7 @@ async def read_records_with_progress(
             signal_queue.put_nowait("stop")
 
         asyncio.get_event_loop().add_signal_handler(signal.SIGINT, stop_signal)
+        asyncio.get_event_loop().add_signal_handler(signal.SIGTERM, stop_signal)
 
         async for record in bucket.query(entry.name, start=start, stop=stop):
             if signal_queue.qsize() > 0:


### PR DESCRIPTION
Closes #24

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature

### What is the current behavior?

See #24 

### What is the new behavior?

We handle SIGINT and SIGTERM signals to finish the current operation and stop commands without errors.

### Does this PR introduce a breaking change?

No

### Other information:
