### PR TITLE
Copy labels and content type in `rcli export bucket`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Copy labels and content type in `rcli export bucket`command, [PR-43](https://github.com/reductstore/reduct-cli/pull/43)
+
 ### Changed
 
 - Move `mirror` command to `export command`, [PR-42](https://github.com/reductstore/reduct-cli/pull/42)

--- a/reduct_cli/export_impl/bucket.py
+++ b/reduct_cli/export_impl/bucket.py
@@ -24,9 +24,11 @@ async def _copy_entry(
         try:
             await dest_bucket.write(
                 entry.name,
-                data=record.read(1024),
+                data=record.read(1024 * 512),
                 content_length=record.size,
                 timestamp=record.timestamp,
+                content_type=record.content_type,
+                labels=record.labels,
             )
         except ReductError as err:
             # filter out the error that the entry already exists

--- a/tests/export/bucket_test.py
+++ b/tests/export/bucket_test.py
@@ -59,6 +59,8 @@ def test__export_bucket_ok(
         data=ANY,
         content_length=records[0].size,
         timestamp=records[0].timestamp,
+        content_type=records[0].content_type,
+        labels=records[0].labels,
     )
     assert walk_async_iterator(dest_bucket.write.await_args_list[0].kwargs["data"]) == [
         b"Hey"
@@ -68,6 +70,8 @@ def test__export_bucket_ok(
         data=ANY,
         content_length=records[1].size,
         timestamp=records[1].timestamp,
+        content_type=records[1].content_type,
+        labels=records[1].labels,
     )
     assert walk_async_iterator(dest_bucket.write.await_args_list[1].kwargs["data"]) == [
         b"Bye"
@@ -81,6 +85,8 @@ def test__export_bucket_ok(
         data=ANY,
         content_length=records[0].size,
         timestamp=records[0].timestamp,
+        content_type=records[0].content_type,
+        labels=records[0].labels,
     )
 
 


### PR DESCRIPTION
Closes #39 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Update

### What is the current behavior?

See #39 

### What is the new behavior?

`rcli export bucket`copy labels and content type. `rcli mirror`is deprecated. 


### Does this PR introduce a breaking change?

No

### Other information:
