### PR TITLE
Add wildcards for list of entries in `rcli export` commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Wildcard support for `--entries` option in `rcli export`
+  command, [PR-51](https://github.com/reductstore/reduct-cli/pull/51)
+
 ### Fixed
 
 - Fix expired query error, [PR-50](https://github.com/reductstore/reduct-cli/pull/50)

--- a/docs/export.md
+++ b/docs/export.md
@@ -70,6 +70,7 @@ Here is a list of the options that you can use with the `rcli export` commands:
 
 * `--entries`: With this option, you can specify the entries that you want to export. The entries should be specified
   as a comma-separated list of entry names (e.g., `--entries=entry1,entry2`).
+  You can also use the `*` wildcard to match all entries with a certain prefix (e.g., `--entries=prefix-*`).
 
 * `--include`: Specify the labels to include in the export. Only data with
   the specified labels will be exported. The labels should be specified as a comma-separated list of label names (e.g.,

--- a/reduct_cli/utils/helpers.py
+++ b/reduct_cli/utils/helpers.py
@@ -155,6 +155,8 @@ def filter_entries(entries: List[EntryInfo], names: List[str]) -> List[EntryInfo
         for name in names:
             if name == entry.name:
                 return True
+            if name.endswith("*") and entry.name.startswith(name[:-1]):
+                return True
         return False
 
     return list(filter(_filter, entries))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,6 +97,14 @@ def _make_src_bucket(mocker, src_settings, records) -> Bucket:
             oldest_record=1000000000,
             latest_record=5000000000,
         ),
+        EntryInfo(
+            name="some-other-entry",
+            size=1050000,
+            block_count=1,
+            record_count=2,
+            oldest_record=1000000000,
+            latest_record=5000000000,
+        ),
     ]
 
     bucket.query.return_value = AsyncIter(records)

--- a/tests/export/bucket_test.py
+++ b/tests/export/bucket_test.py
@@ -162,7 +162,28 @@ def test__export_bucket_specific_entry(runner, conf, src_bucket):
 def test__export_bucket_multiple_specific_entry(runner, conf, src_bucket):
     """Should export bucket multiple specific entries"""
     result = runner(
-        f"-c {conf} export bucket test/src_bucket test/dest_bucket --entries=entry-2,entry-1"
+        f"-c {conf} export bucket test/src_bucket test/dest_bucket --entries=entry-*"
+    )
+    assert result.exit_code == 0
+    assert src_bucket.query.call_args_list == [
+        call("entry-1", start=ANY, stop=ANY, include={}, exclude={}, ttl=ANY),
+        call("entry-2", start=ANY, stop=ANY, include={}, exclude={}, ttl=ANY),
+    ]
+    src_bucket.query.call_args_list = []
+
+    result = runner(
+        f"-c {conf} export bucket test/src_bucket test/dest_bucket "
+        f"--entries=entry-1,some-other-entry"
+    )
+    assert result.exit_code == 0
+    assert src_bucket.query.call_args_list == [
+        call("entry-1", start=ANY, stop=ANY, include={}, exclude={}, ttl=ANY),
+        call("some-other-entry", start=ANY, stop=ANY, include={}, exclude={}, ttl=ANY),
+    ]
+    src_bucket.query.call_args_list = []
+
+    result = runner(
+        f"-c {conf} export bucket test/src_bucket test/dest_bucket --entries=entry-1,entry-2"
     )
     assert result.exit_code == 0
     assert src_bucket.query.call_args_list == [


### PR DESCRIPTION
Closes #48 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature

### What is the current behavior?

See #48 

### What is the new behavior?

We can use wildcard:

```
rcli export  folder instance/data ./.export --entries=acc-*
```

### Does this PR introduce a breaking change?

No

### Other information:
