### PR TITLE
Stop creating folder with bucket name in `rcli export folder`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Wildcard support for `--entries` option in `rcli export`
   command, [PR-51](https://github.com/reductstore/reduct-cli/pull/51)
+- Stop creating folder with bucket name
+  in `rcli export folder`, [PR-52](https://github.com/reductstore/reduct-cli/pull/52)
 
 ### Fixed
 

--- a/reduct_cli/export_impl/folder.py
+++ b/reduct_cli/export_impl/folder.py
@@ -42,7 +42,7 @@ async def export_to_folder(
 ) -> None:
     """Export data from SRC bucket to DST folder"""
     bucket: Bucket = await client.get_bucket(bucket_name)
-    folder_path = Path(dest) / bucket_name
+    folder_path = Path(dest)
     folder_path.mkdir(parents=True, exist_ok=True)
     sem = asyncio.Semaphore(kwargs["parallel"])
 

--- a/tests/export/folder_test.py
+++ b/tests/export/folder_test.py
@@ -58,12 +58,12 @@ def test__export_to_folder_ok_with_interval(
     )
 
     assert (
-        export_path / "src_bucket" / "entry-1" / f"{records[0].timestamp}.png"
+        export_path / "entry-1" / f"{records[0].timestamp}.png"
     ).read_bytes() == b"Hey"
 
     # record 2 has no content type so it should be saved as .bin
     assert (
-        export_path / "src_bucket" / "entry-2" / f"{records[1].timestamp}.bin"
+        export_path / "entry-2" / f"{records[1].timestamp}.bin"
     ).read_bytes() == b"Bye"
 
 
@@ -159,10 +159,10 @@ def test__export_to_folder_with_ext_flag(runner, conf, records, export_path):
     assert result.exit_code == 0
 
     assert (
-        export_path / "src_bucket" / "entry-1" / f"{records[0].timestamp}.txt"
+        export_path / "entry-1" / f"{records[0].timestamp}.txt"
     ).read_bytes() == b"Hey"
     assert (
-        export_path / "src_bucket" / "entry-2" / f"{records[1].timestamp}.txt"
+        export_path / "entry-2" / f"{records[1].timestamp}.txt"
     ).read_bytes() == b"Bye"
 
 


### PR DESCRIPTION
Closes #49

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature

### What is the current behavior?

See #49 

### What is the new behavior?

We export entries directly into the export folder.

### Does this PR introduce a breaking change?

No

### Other information:
