### PR TITLE
Add `--with-metadata` flag for `rcli export folder` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `--with-metadata` flag for `rcli export folder` command to export metadata
+  along with the records, [PR-55](https://github.com/reductstore/reduct-cli/pull/55)
+
 ## [0.7.0] - 2023-02-19
 
 ### Added

--- a/docs/export.md
+++ b/docs/export.md
@@ -40,7 +40,7 @@ that you want to use (see below for a list of available options), `SRC` with the
 data from, and `DEST` with the destination bucket where you want to save the copied data:
 
 ```
-rcli mirror [OPTIONS] SRC DEST
+rcli export bucket [OPTIONS] SRC DEST
 ```
 
 `SRC` and `DEST` should be in the format `ALIAS/BUCKET_NAME`, where `ALIAS` is the alias that you created for your
@@ -79,6 +79,14 @@ Here is a list of the options that you can use with the `rcli export` commands:
 * `--exclude`: Specify the labels to exclude from the export. Data with
   the specified labels will not be exported. The labels should be specified as a comma-separated list of label names (
   e.g., and values (e.g., `--exclude= color=red,size=big`).
+
+* `--ext`: Specify the file extension that you want to use for the exported data files. If not specified, the default
+  extension will be guessed based on the MIME content type of the data. Only for `rcli export folder`.
+
+* `--with-metadata`: If this option is specified, the CLI client creates a metadata file in JSON format for each
+  exported data record.
+  The metadata file contains information like the timestamp, content type, size and the labels that were applied to the
+  data. Only for `rcli export folder`.
 
 You also can use the global `--parallel` option to specify the number of entries that you want to export in parallel:
 

--- a/reduct_cli/export.py
+++ b/reduct_cli/export.py
@@ -61,6 +61,11 @@ def export():
     "--ext",
     help="Extension for exported files, if not specified, will be guessed from content type",
 )
+@click.option(
+    "--with-metadata/--no-with-metadata",
+    help="Export metadata along with the data",
+    default=False,
+)
 @click.pass_context
 def folder(
     ctx,
@@ -72,6 +77,7 @@ def folder(
     include: str,
     exclude: str,
     ext: Optional[str],
+    with_metadata: bool,
 ):  # pylint: disable=too-many-arguments
     """Export data from SRC bucket to DST folder
 
@@ -101,6 +107,7 @@ def folder(
                 exclude=exclude.split(","),
                 ext=ext,
                 timeout=ctx.obj["timeout"],
+                with_metadata=with_metadata,
             )
         )
 

--- a/reduct_cli/export_impl/folder.py
+++ b/reduct_cli/export_impl/folder.py
@@ -35,7 +35,9 @@ async def _export_entry(
             async for chunk in record.read(1024 * 512):
                 file.write(chunk)
         if with_meta:
-            with open(entry_path / f"{record.timestamp}.json", "w") as file:
+            with open(
+                entry_path / f"{record.timestamp}.json", "w", encoding="utf-8"
+            ) as file:
                 json.dump(
                     {
                         "timestamp": record.timestamp,

--- a/tests/export/folder_test.py
+++ b/tests/export/folder_test.py
@@ -204,10 +204,8 @@ def test__export_to_folder_with_ttl(runner, conf, src_bucket, export_path):
     )
 
 
-@pytest.mark.usefixtures("set_alias", "client")
-def test__export_to_folder_with_metadata(
-    runner, conf, src_bucket, export_path, records
-):
+@pytest.mark.usefixtures("set_alias", "client", "src_bucket")
+def test__export_to_folder_with_metadata(runner, conf, export_path, records):
     """Should export a bucket to a folder with metadata"""
     result = runner(
         f"-c {conf} export folder test/src_bucket {export_path} --with-metadata"


### PR DESCRIPTION
Closes #54 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature

### What is the current behavior?

See #54 

### What is the new behavior?

If a user use `--with-metadata` flag, the CLI tool creates a JSON file for each record with the following metadata:

```json
{
        "timestamp": 12491823719283,
        "content_type": "image/jpeg",
        "size": 10000,
        "labels": {},
}
```

### Does this PR introduce a breaking change?

No

### Other information:
