### PR TITLE
Support integers for `--start` and `--stop` options of `rcli export` commands

### DIFF
--- a/docs/export.md
+++ b/docs/export.md
@@ -62,11 +62,11 @@ Here is a list of the options that you can use with the `rcli export` commands:
 
 * `--start`: This option allows you to specify a starting time point for the data that you want to export. Data with
   timestamps newer than this time point will be included in the export. The time point should be in ISO format (e.g.,
-  2022-01-01T00:00:00Z).
+  2022-01-01T00:00:00Z) or Unix timestamp in milliseconds (e.g., 1633046400000).
 
 * `--stop`: This option allows you to specify an ending time point for the data that you want to export. Data with
   timestamps older than this time point will be included in the export. The time point should be in ISO format (e.g.,
-  2022-01-01T00:00:00Z).
+  2022-01-01T00:00:00Z) or Unix timestamp in milliseconds (e.g., 1633046400000).
 
 * `--entries`: With this option, you can specify the entries that you want to export. The entries should be specified
   as a comma-separated list of entry names (e.g., `--entries=entry1,entry2`).

--- a/reduct_cli/export.py
+++ b/reduct_cli/export.py
@@ -16,13 +16,16 @@ run = loop().run_until_complete
 
 start_option = click.option(
     "--start",
-    help="Export records with timestamps newer than this time point in ISO format or Unix timestamp in microseconds",
+    help="Export records with timestamps newer than this time point in ISO format"
+    " or Unix timestamp in microseconds",
 )
 
 stop_option = click.option(
     "--stop",
-    help="Export records  with timestamps older than this time point in ISO format or Unix timestamp in microseconds",
+    help="Export records  with timestamps older than this time point in ISO format"
+    " or Unix timestamp in microseconds",
 )
+
 entries_option = click.option(
     "--entries",
     help="Export only these entries, separated by comma",

--- a/reduct_cli/export.py
+++ b/reduct_cli/export.py
@@ -16,12 +16,12 @@ run = loop().run_until_complete
 
 start_option = click.option(
     "--start",
-    help="Export records with timestamps newer than this time point in ISO format",
+    help="Export records with timestamps newer than this time point in ISO format or Unix timestamp in microseconds",
 )
 
 stop_option = click.option(
     "--stop",
-    help="Export records  with timestamps older than this time point in ISO format",
+    help="Export records  with timestamps older than this time point in ISO format or Unix timestamp in microseconds",
 )
 entries_option = click.option(
     "--entries",

--- a/reduct_cli/utils/helpers.py
+++ b/reduct_cli/utils/helpers.py
@@ -68,9 +68,13 @@ async def read_records_with_progress(
     """
 
     def _to_timestamp(date: str) -> int:
-        return int(
-            datetime.fromisoformat(date.replace("Z", "+00:00")).timestamp() * 1000_000
-        )
+        try:
+            return int(date)
+        except ValueError:
+            return int(
+                datetime.fromisoformat(date.replace("Z", "+00:00")).timestamp()
+                * 1000_000
+            )
 
     start = _to_timestamp(kwargs["start"]) if kwargs["start"] else entry.oldest_record
     stop = _to_timestamp(kwargs["stop"]) if kwargs["stop"] else entry.latest_record

--- a/tests/utils/helpers_test.py
+++ b/tests/utils/helpers_test.py
@@ -1,0 +1,58 @@
+"""Unit tests for helpers"""
+from asyncio import Semaphore
+
+import pytest
+from reduct import EntryInfo
+from rich.progress import Progress
+
+from reduct_cli.utils.helpers import read_records_with_progress
+
+
+@pytest.fixture(name="progress")
+def _make_progress(mocker):
+    return mocker.Mock(spec=Progress)
+
+
+@pytest.fixture(name="default_kwargs")
+def _make_default_kwargs():
+    return dict(
+        sem=Semaphore(1),
+        include={},
+        exclude={},
+        timeout=0,
+        parallel=1,
+    )
+
+
+@pytest.fixture(name="entry")
+def _make_entry(mocker):
+    entry_info = mocker.Mock(spec=EntryInfo)
+    entry_info.name = "entry-1"
+    return entry_info
+
+
+@pytest.mark.parametrize(
+    "start,stop",
+    [("1000000000", "5000000000"), ("2001-09-09T00:00:00", "2028-09-09T00:00:00")],
+)
+@pytest.mark.asyncio
+async def test__read_records_with_progress_with_integers(
+    entry, src_bucket, start, stop, progress, default_kwargs
+):
+    """Should read records with integers or ISO time strings"""
+
+    result = [
+        record
+        async for record in read_records_with_progress(
+            entry,
+            src_bucket,
+            progress,
+            start=start,
+            stop=stop,
+            **default_kwargs,
+        )
+    ]
+
+    assert len(result) == 2
+    assert result[0].timestamp == 1000000000
+    assert result[1].timestamp == 5000000000


### PR DESCRIPTION
Closes #53

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature 

### What is the current behavior?

See #53

### What is the new behavior?

Now you can use Unix timestamp in microseconds or just as a range of IDs for exporting data:

```
rcli export folder serve/bucket . --start 0 --stop 10
```

### Does this PR introduce a breaking change?

No

### Other information:
