### PR TITLE
Fix `bucket create` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `--with-metadata` flag for `rcli export folder` command to export metadata
   along with the records, [PR-55](https://github.com/reductstore/reduct-cli/pull/55)
 - Support integers for --start and --stop options of rcli export
-  commands, [PR-56]((https://github.com/reductstore/reduct-cli/pull/56)
+  commands, [PR-56](https://github.com/reductstore/reduct-cli/pull/56)
 
 ## [0.7.0] - 2023-02-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Exception in `bucket create` command, [PR-57](https://github.com/reductstore/reduct-cli/pull/57)
+
 ## [0.8.0] - 2023-03-08
 
 ### Added

--- a/reduct_cli/bucket.py
+++ b/reduct_cli/bucket.py
@@ -190,7 +190,7 @@ def create(
     PATH should contain alias name and bucket name - ALIAS/BUCKET_NAME
     """
     alias_name, bucket_name = parse_path(path)
-    client = build_client(ctx, alias_name, ctx.obj["timeout"])
+    client = build_client(ctx.obj["config_path"], alias_name, ctx.obj["timeout"])
     with error_handle():
         settings = BucketSettings(
             quota_type=quota_type,

--- a/tests/bucket_test.py
+++ b/tests/bucket_test.py
@@ -1,5 +1,4 @@
 """Unit tests for bucket commands"""
-from pathlib import PosixPath
 
 import pytest
 from reduct import BucketInfo, Client, Bucket, BucketSettings, QuotaType, EntryInfo

--- a/tests/bucket_test.py
+++ b/tests/bucket_test.py
@@ -1,4 +1,6 @@
 """Unit tests for bucket commands"""
+from pathlib import PosixPath
+
 import pytest
 from reduct import BucketInfo, Client, Bucket, BucketSettings, QuotaType, EntryInfo
 from rich.console import Console
@@ -46,11 +48,15 @@ def _make_bucket(mocker) -> Bucket:
     return bucket
 
 
+@pytest.fixture(name="build_client_func")
+def _build_client(mocker) -> Client:
+    return mocker.patch("reduct_cli.bucket.build_client")
+
+
 @pytest.fixture(name="client")
-def _make_client(mocker, bucket) -> Client:
-    kls = mocker.patch("reduct_cli.bucket.build_client")
-    kls.return_value = mocker.Mock(spec=Client)
-    kls.return_value.list.return_value = [
+def _make_client(mocker, bucket, build_client_func) -> Client:
+    build_client_func.return_value = mocker.Mock(spec=Client)
+    build_client_func.return_value.list.return_value = [
         BucketInfo(
             name="bucket-1",
             entry_count=1,
@@ -67,8 +73,8 @@ def _make_client(mocker, bucket) -> Client:
         ),
     ]
 
-    kls.return_value.get_bucket.return_value = bucket
-    return kls.return_value
+    build_client_func.return_value.get_bucket.return_value = bucket
+    return build_client_func.return_value
 
 
 @pytest.mark.usefixtures("set_alias", "client")
@@ -164,13 +170,14 @@ def test__show_error(runner, conf, client):
 
 
 @pytest.mark.usefixtures("set_alias")
-def test__create_bucket_default(runner, conf, client):
+def test__create_bucket_default(runner, conf, client, build_client_func):
     """Should create a bucket with default settings"""
     result = runner(f"-c {conf} bucket create test/bucket-1")
     assert result.output == "Bucket 'bucket-1' created\n"
     assert result.exit_code == 0
 
     client.create_bucket.assert_called_with("bucket-1", BucketSettings())
+    build_client_func.assert_called_with(conf, "test", 5)
 
 
 @pytest.mark.usefixtures("set_alias")


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

A user has an expectation when they try to create a bucket:

```
$ rcli bucket create local/datasets 
Traceback (most recent call last):
  File "/home/flipback/.local/bin/rcli", line 8, in <module>
    sys.exit(main())
  File "/home/flipback/.local/lib/python3.10/site-packages/reduct_cli/__init__.py", line 8, in main
    return cli(obj={})  # pylint:disable=unexpected-keyword-arg, no-value-for-parameter
  File "/home/flipback/.local/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/home/flipback/.local/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/home/flipback/.local/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/flipback/.local/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/flipback/.local/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/flipback/.local/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/flipback/.local/lib/python3.10/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/flipback/.local/lib/python3.10/site-packages/reduct_cli/bucket.py", line 193, in create
    client = build_client(ctx, alias_name, ctx.obj["timeout"])
  File "/home/flipback/.local/lib/python3.10/site-packages/reduct_cli/utils/helpers.py", line 34, in build_client
    alias_ = get_alias(config_path, alias)
  File "/home/flipback/.local/lib/python3.10/site-packages/reduct_cli/utils/helpers.py", line 23, in get_alias
    conf = read_config(config_path)
  File "/home/flipback/.local/lib/python3.10/site-packages/reduct_cli/config.py", line 33, in read_config
    with open(path, "r", encoding="utf8") as config_file:
TypeError: expected str, bytes or os.PathLike object, not Context
```
### What is the new behavior?

It was a wrong call of `build_client` function. I fixed it and added a test.

### Does this PR introduce a breaking change?

No

### Other information:
