### PR TITLE
Use batched query and fix speed calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix speed calculation for `rcli export` command, [PR-61](https://github.com/reductstore/reduct-cli/pull/61)
+
 ## [0.8.2] - 2023-06-05
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,10 +29,11 @@ classifiers = [
 ]
 
 dependencies = [
-    "reduct-py~=1.4",
+    "reduct-py~=1.5",
     "click~=8.1",
     "tomlkit~=0.11",
     "rich~=12.6",
+    "httpx[http2]~=0.19",
 ]
 
 [project.optional-dependencies]

--- a/reduct_cli/utils/helpers.py
+++ b/reduct_cli/utils/helpers.py
@@ -129,7 +129,6 @@ async def read_records_with_progress(
                 speed = sum(s[0] for s in stats) / (stats[-1][1] - stats[0][1])
                 stats = stats[-50:]
 
-
             yield record
 
             progress.update(

--- a/reduct_cli/utils/helpers.py
+++ b/reduct_cli/utils/helpers.py
@@ -125,11 +125,10 @@ async def read_records_with_progress(
 
             exported_size += record.size
             stats.append((record.size, time.time()))
-            if len(stats) > 10:
-                stats.pop(0)
-
-            if len(stats) > 1:
+            if len(stats) > 100:
                 speed = sum(s[0] for s in stats) / (stats[-1][1] - stats[0][1])
+                stats = stats[-50:]
+
 
             yield record
 
@@ -137,7 +136,7 @@ async def read_records_with_progress(
                 task,
                 description=f"Entry '{entry.name}' "
                 f"(copied {count} records ({pretty_size(exported_size)}), "
-                f"speed {pretty_size(speed)}/s)",
+                f"speed {pretty_size(speed) if speed else '? B'}/s)",
                 advance=record.timestamp - last_time,
                 refresh=True,
             )


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Fix

### What is the current behavior?

After reduct-py~=1.5, we use batched query. However, speed calculation worked weird for this case.

### What is the new behavior?

The speed is calculated each 50th record.


### Does this PR introduce a breaking change?

No

### Other information:
