### PR TITLE
Reuse HTTP session to improve performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Reuse HTTP session to improve performance, [PR-64](https://github.com/reductstore/reduct-cli/pull/64)
+
 ## [0.8.3] - 2023-06-30
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "reduct-py~=1.5",
+    "reduct-py~=1.6",
     "click~=8.1",
     "tomlkit~=0.11",
     "rich~=12.6",

--- a/reduct_cli/export_impl/folder.py
+++ b/reduct_cli/export_impl/folder.py
@@ -57,16 +57,17 @@ async def export_to_folder(
     **kwargs,
 ) -> None:
     """Export data from SRC bucket to DST folder"""
-    bucket: Bucket = await client.get_bucket(bucket_name)
-    folder_path = Path(dest)
-    folder_path.mkdir(parents=True, exist_ok=True)
-    sem = asyncio.Semaphore(kwargs["parallel"])
+    async with client as client:
+        bucket: Bucket = await client.get_bucket(bucket_name)
+        folder_path = Path(dest)
+        folder_path.mkdir(parents=True, exist_ok=True)
+        sem = asyncio.Semaphore(kwargs["parallel"])
 
-    with Progress() as progress:
-        tasks = [
-            _export_entry(folder_path, entry, bucket, progress, sem, **kwargs)
-            for entry in filter_entries(
-                await bucket.get_entry_list(), kwargs["entries"]
-            )
-        ]
-        await asyncio.gather(*tasks)
+        with Progress() as progress:
+            tasks = [
+                _export_entry(folder_path, entry, bucket, progress, sem, **kwargs)
+                for entry in filter_entries(
+                    await bucket.get_entry_list(), kwargs["entries"]
+                )
+            ]
+            await asyncio.gather(*tasks)

--- a/tests/export/bucket_test.py
+++ b/tests/export/bucket_test.py
@@ -19,9 +19,10 @@ def _make_dest_bucket(mocker) -> Bucket:
 @pytest.fixture(name="client")
 def _make_client(mocker, src_bucket, dest_bucket) -> Client:
     kls = mocker.patch("reduct_cli.export.build_client")
-    client = mocker.Mock(spec=Client)
+    client = mocker.MagicMock(spec=Client)
     client.get_bucket.return_value = src_bucket
     client.create_bucket.return_value = dest_bucket
+    client.__aenter__.return_value = client
 
     kls.return_value = client
     return client

--- a/tests/export/folder_test.py
+++ b/tests/export/folder_test.py
@@ -12,8 +12,9 @@ from reduct import Client
 @pytest.fixture(name="client")
 def _make_client(mocker, src_bucket) -> Client:
     kls = mocker.patch("reduct_cli.export.build_client")
-    client = mocker.Mock(spec=Client)
+    client = mocker.MagicMock(spec=Client)
     client.get_bucket.return_value = src_bucket
+    client.__aenter__.return_value = client
 
     kls.return_value = client
     return client


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Performance

### What is the current behavior?

ReductClient closes a session after each request. This slows down the export commands. 

### What is the new behavior?

I've updated `reduct-py` up to version 1.6 and use the asynchronous context manger to reuse the session. 

### Does this PR introduce a breaking change?

No

### Other information:
