### PR TITLE
Implement 'bucket rm --only-entries' command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Update pip
         run: python3 -m pip install --no-cache --upgrade pip setuptools wheel
 
@@ -25,7 +25,7 @@ jobs:
     needs: format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Update pip
         run: python3 -m pip install --no-cache --upgrade pip
 
@@ -70,7 +70,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{matrix.python}}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/download-artifact@master
         with:
           name: package
@@ -90,7 +90,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/download-artifact@master
         with:
           name: package

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ blob data. It is written in Python and uses the [ReductStore Client SDK for Pyth
 
 ## Features
 
-* Support for ReductStore API v1.5
+* Support for ReductStore API v1.6
 * Easy management of buckets and tokens
 * Ability to check the status of a storage engine
 * Aliases for storing server credentials

--- a/docs/bucket.md
+++ b/docs/bucket.md
@@ -80,3 +80,9 @@ rcli bucket rm test-storage/bucket-1
 
 !!!Warning
     When you remove a bucket from your storage engine, you delete all of its data. Use this command with caution.
+
+You also can remove only selected entries from a bucket using the `--only-entries` option:
+
+```shell
+rcli bucket rm test-storage/bucket-1 --only-entries entry-1,entry-2,old-*
+```

--- a/reduct_cli/bucket.py
+++ b/reduct_cli/bucket.py
@@ -237,7 +237,7 @@ def update(
 @bucket.command()
 @click.argument("path")
 @click.option(
-    "--only-entries", "-e", help="Don't remove a bucket but only some entries"
+    "--only-entries", "-e", help="Don't remove a bucket but only selected entries"
 )
 @click.pass_context
 def rm(ctx, path: str, only_entries: Optional[str]):

--- a/reduct_cli/bucket.py
+++ b/reduct_cli/bucket.py
@@ -263,7 +263,9 @@ def rm(ctx, path: str, only_entries: Optional[str]):
             return
 
         console.print(
-            f"All data in entries [b]'{', '.join([entry.name for entry in entries])}'[/b] will be [b]REMOVED[/b]."
+            f"All data in entries [b]'"
+            f"{', '.join([entry.name for entry in entries])}'"
+            f"[/b] will be [b]REMOVED[/b]."
         )
         if click.confirm("Do you want to continue?"):
             for entry in entries:

--- a/reduct_cli/bucket.py
+++ b/reduct_cli/bucket.py
@@ -3,14 +3,14 @@ from asyncio import new_event_loop as loop
 from typing import List, Optional
 
 import click
-from reduct import BucketInfo, BucketSettings, QuotaType
+from reduct import BucketInfo, BucketSettings, QuotaType, Bucket
 from rich.layout import Layout
 from rich.panel import Panel
 from rich.table import Table
 
 from reduct_cli.utils.consoles import console
 from reduct_cli.utils.error import error_handle
-from reduct_cli.utils.helpers import parse_path, build_client
+from reduct_cli.utils.helpers import parse_path, build_client, filter_entries
 from reduct_cli.utils.humanize import pretty_size, print_datetime, parse_ci_size
 from reduct_cli.utils.humanize import pretty_time_interval
 
@@ -236,20 +236,50 @@ def update(
 
 @bucket.command()
 @click.argument("path")
+@click.option(
+    "--only-entries", "-e", help="Don't remove a bucket but only some entries"
+)
 @click.pass_context
-def rm(ctx, path: str):
+def rm(ctx, path: str, only_entries: Optional[str]):
     """
     Remove bucket
 
     PATH should contain alias name and bucket name - ALIAS/BUCKET_NAME
     """
-    with error_handle():
-        bucket_ = run(_get_bucket_by_path(ctx, path))
-        console.print(
-            f"All data in bucket [b]'{bucket_.name}'[/b] will be [b]REMOVED[/b]."
-        )
+
+    async def remove_bucket(bkt: Bucket):
+        console.print(f"All data in bucket [b]'{bkt.name}'[/b] will be [b]REMOVED[/b].")
         if click.confirm("Do you want to continue?"):
-            run(bucket_.remove())
-            console.print(f"Bucket '{bucket_.name}' was removed")
+            await bkt.remove()
+            console.print(f"Bucket '{bkt.name}' was removed")
         else:
             console.print("Canceled")
+
+    async def remove_entries(bkt: Bucket):
+        entries = await bkt.get_entry_list()
+        entries = filter_entries(entries, only_entries.split(","))
+        if not entries:
+            console.print("No entries found")
+            return
+
+        console.print(
+            f"All data in entries [b]'{', '.join([entry.name for entry in entries])}'[/b] will be [b]REMOVED[/b]."
+        )
+        if click.confirm("Do you want to continue?"):
+            for entry in entries:
+                await bkt.remove_entry(entry.name)
+            console.print(
+                f"Entries '{', '.join([entry.name for entry in entries])}' were removed"
+            )
+        else:
+            console.print("Canceled")
+
+    async def cmd():
+        bucket_ = await _get_bucket_by_path(ctx, path)
+        if not only_entries:
+            await remove_bucket(bucket_)
+        else:
+            await remove_entries(bucket_)
+
+    with error_handle():
+        run(cmd())

--- a/reduct_cli/utils/helpers.py
+++ b/reduct_cli/utils/helpers.py
@@ -155,6 +155,7 @@ def filter_entries(entries: List[EntryInfo], names: List[str]) -> List[EntryInfo
 
     def _filter(entry):
         for name in names:
+            name = name.strip()
             if name == entry.name:
                 return True
             if name.endswith("*") and entry.name.startswith(name[:-1]):

--- a/tests/bucket_test.py
+++ b/tests/bucket_test.py
@@ -348,8 +348,8 @@ def test__remove_only_entries_error(runner, conf, bucket):
     assert result.exit_code == 1
 
 
-@pytest.mark.usefixtures("set_alias", "client")
-def test__remove_only_entries_error_entry_not_found(runner, conf, bucket):
+@pytest.mark.usefixtures("set_alias", "client", "bucket")
+def test__remove_only_entries_error_entry_not_found(runner, conf):
     """Should remove entries selected by wildcard"""
     result = runner(
         f"-c {conf} bucket rm test/bucket-1 --only-entries entry-* ", input="Y\n"

--- a/tests/bucket_test.py
+++ b/tests/bucket_test.py
@@ -41,7 +41,15 @@ def _make_bucket(mocker) -> Bucket:
             record_count=10000,
             oldest_record=1000000000,
             latest_record=5000000000,
-        )
+        ),
+        EntryInfo(
+            name="entry-2",
+            size=1050000,
+            block_count=100,
+            record_count=10000,
+            oldest_record=1000000000,
+            latest_record=5000000000,
+        ),
     ]
 
     return bucket
@@ -288,3 +296,67 @@ def test__remove_error(runner, conf, bucket):
         "Aborted!\n"
     )
     assert result.exit_code == 1
+
+
+@pytest.mark.usefixtures("set_alias", "client")
+def test__remove_only_entries(runner, conf, bucket):
+    """Should remove selected entries from a bucket"""
+    result = runner(
+        f"-c {conf} bucket rm test/bucket-1 --only-entries entry-1,entry-2 ",
+        input="Y\n",
+    )
+    assert result.output == (
+        "All data in entries 'entry-1, entry-2' will be REMOVED.\n"
+        "Do you want to continue? [y/N]: Y\n"
+        "Entries 'entry-1, entry-2' were removed\n"
+    )
+    assert result.exit_code == 0
+
+    assert bucket.remove_entry.call_args_list[0][0][0] == "entry-1"
+    assert bucket.remove_entry.call_args_list[1][0][0] == "entry-2"
+
+
+@pytest.mark.usefixtures("set_alias", "client")
+def test__remove_only_entries_canceled(runner, conf, bucket):
+    """Should cancel removing selected entries from a bucket"""
+    result = runner(
+        f"-c {conf} bucket rm test/bucket-1 --only-entries entry-1 ", input="N\n"
+    )
+    assert result.output == (
+        "All data in entries 'entry-1' will be REMOVED.\n"
+        "Do you want to continue? [y/N]: N\n"
+        "Canceled\n"
+    )
+    assert result.exit_code == 0
+
+    bucket.remove_entry.assert_not_called()
+
+
+@pytest.mark.usefixtures("set_alias", "client")
+def test__remove_only_entries_error(runner, conf, bucket):
+    """Should print error if something got wrong"""
+    bucket.remove_entry.side_effect = RuntimeError("Oops")
+    result = runner(
+        f"-c {conf} bucket rm test/bucket-1 --only-entries entry-1 ", input="Y\n"
+    )
+    assert result.output == (
+        "All data in entries 'entry-1' will be REMOVED.\n"
+        "Do you want to continue? [y/N]: Y\n"
+        "[RuntimeError] Oops\n"
+        "Aborted!\n"
+    )
+    assert result.exit_code == 1
+
+
+@pytest.mark.usefixtures("set_alias", "client")
+def test__remove_only_entries_error_entry_not_found(runner, conf, bucket):
+    """Should remove entries selected by wildcard"""
+    result = runner(
+        f"-c {conf} bucket rm test/bucket-1 --only-entries entry-* ", input="Y\n"
+    )
+    assert result.output == (
+        "All data in entries 'entry-1, entry-2' will be REMOVED.\n"
+        "Do you want to continue? [y/N]: Y\n"
+        "Entries 'entry-1, entry-2' were removed\n"
+    )
+    assert result.exit_code == 0


### PR DESCRIPTION
Closes #62 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature

### What is the current behavior?

We can remove only  a bucket by using:

```
rcli bucket rm ALIAS/BUCKET
```

### What is the new behavior?

We can remove only selected entries:

```
rcli bucket rm ALIAS/BUCKET --only-entries entry-1,entry-2,some-*
``` 

### Does this PR introduce a breaking change?

No

### Other information:
