### PR TITLE
RS-115: Fix too high permissions for exporting data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- RS-115: Fix too high permissions for exporting data, [PR-70](https://github.com/reductstore/reduct-cli/pull/70)
+
 ## [0.9.2] - 2023-10-28
 
 ### Fixed

--- a/reduct_cli/export_impl/bucket.py
+++ b/reduct_cli/export_impl/bucket.py
@@ -49,7 +49,8 @@ async def export_to_bucket(
 
         dest_bucket: Bucket
         try:
-            # we don't use exist_ok here because it needs full access to the bucket even if it exists
+            # we don't use exist_ok here because it needs full access to the bucket
+            # even if it exists
             dest_bucket = await dest.get_bucket(dest_bucket_name)
         except ReductError as err:
             if err.status_code != 404:

--- a/reduct_cli/export_impl/bucket.py
+++ b/reduct_cli/export_impl/bucket.py
@@ -46,9 +46,17 @@ async def export_to_bucket(
     """Export data from SRC bucket to DST bucket"""
     async with src as src, dest as dest:
         src_bucket: Bucket = await src.get_bucket(src_bucket_name)
-        dest_bucket: Bucket = await dest.create_bucket(
-            dest_bucket_name, settings=await src_bucket.get_settings(), exist_ok=True
-        )
+
+        dest_bucket: Bucket
+        try:
+            # we don't use exist_ok here because it needs full access to the bucket even if it exists
+            dest_bucket = await dest.get_bucket(dest_bucket_name)
+        except ReductError as err:
+            if err.status_code != 404:
+                raise err
+            dest_bucket: Bucket = await dest.create_bucket(
+                dest_bucket_name, settings=await src_bucket.get_settings()
+            )
 
         sem = asyncio.Semaphore(kwargs["parallel"])
         with Progress() as progress:

--- a/tests/alias_test.py
+++ b/tests/alias_test.py
@@ -44,16 +44,11 @@ def test__add_alias_with_invalid_url(runner, conf):
     """Should not add an alias if the url is invalid"""
     result = runner(f"-c {conf} alias add storage", input="invalid_url\ntoken\n")
     assert result.exit_code == 1
-    assert result.output.split("\n") == [
+    assert result.output.split("\n")[:4] == [
         "URL: invalid_url",
         "API Token []: token",
         "[ValidationError] 1 validation error for Alias",
         "url",
-        "  Input should be a valid URL, relative URL without a base ",
-        "    For further information visit "
-        "https://errors.pydantic.dev/2.4/v/url_parsing",
-        "Aborted!",
-        "",
     ]
 
 

--- a/tests/export/bucket_test.py
+++ b/tests/export/bucket_test.py
@@ -41,7 +41,8 @@ def walk_async_iterator(iterator: AsyncIter):
 def test__export_bucket_ok(
     runner, conf, client, src_settings, src_bucket, dest_bucket, records
 ):  # pylint: disable=too-many-arguments
-    """Should export data from a bucket to another one and create destination bucket if it doesn't exist"""
+    """Should export data from a bucket to another one
+    and create destination bucket if it doesn't exist"""
     client.get_bucket.side_effect = [src_bucket, ReductError(404, "Not found")]
 
     result = runner(f"-c {conf} export bucket test/src_bucket test/dest_bucket")

--- a/tests/export/bucket_test.py
+++ b/tests/export/bucket_test.py
@@ -41,16 +41,15 @@ def walk_async_iterator(iterator: AsyncIter):
 def test__export_bucket_ok(
     runner, conf, client, src_settings, src_bucket, dest_bucket, records
 ):  # pylint: disable=too-many-arguments
-    """Should export data from a bucket to another one"""
+    """Should export data from a bucket to another one and create destination bucket if it doesn't exist"""
+    client.get_bucket.side_effect = [src_bucket, ReductError(404, "Not found")]
 
     result = runner(f"-c {conf} export bucket test/src_bucket test/dest_bucket")
     assert "Entry 'entry-1' (copied 1 records (6 B)" in result.output
     assert result.exit_code == 0
 
-    client.get_bucket.assert_called_with("src_bucket")
-    client.create_bucket.assert_called_with(
-        "dest_bucket", settings=src_settings, exist_ok=True
-    )
+    assert client.get_bucket.call_args_list == [call("src_bucket"), call("dest_bucket")]
+    client.create_bucket.assert_called_with("dest_bucket", settings=src_settings)
 
     assert src_bucket.query.call_args_list[0] == call(
         "entry-1", start=1000000000, stop=5000000000, include={}, exclude={}, ttl=ANY


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

In order to export data from one bucket to another one, we need full access even if we don't create a new bucket because we use the `Bucket.create_bucket(exist_ok=True)` call.
 
### What is the new behavior?

We check if the bucket exists instead of trying to create it. This means we only need read and write permissions, not full access.

### Does this PR introduce a breaking change?

No

### Other information:
